### PR TITLE
Update FastNoise2 to latest C++ version with WASM/Emscripten support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,123 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-native:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y cmake libclang-dev
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install cmake llvm
+
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: choco install cmake llvm -y
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build
+        run: cargo build --release --workspace
+
+      - name: Run tests
+        run: cargo test --release --workspace
+
+  build-wasm:
+    name: Build (WASM/Emscripten)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add wasm32-unknown-emscripten target
+        run: rustup target add wasm32-unknown-emscripten
+
+      - name: Setup Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 'latest'
+
+      - name: Verify Emscripten
+        run: emcc --version
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake libclang-dev
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: wasm-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: wasm-cargo-
+
+      - name: Build WASM demo
+        working-directory: fastnoise2-rs/examples/wasm_emscripten
+        run: |
+          EMCC_CFLAGS="-s MODULARIZE=1 -s EXPORT_NAME=createFastNoise2Module -s EXPORTED_FUNCTIONS=_generate_noise,_malloc,_free,_main -s EXPORTED_RUNTIME_METHODS=HEAPU8 -s ALLOW_MEMORY_GROWTH=1 -s ERROR_ON_UNDEFINED_SYMBOLS=0 -O3" \
+            cargo build --release --target wasm32-unknown-emscripten
+
+      - name: Verify WASM output
+        working-directory: fastnoise2-rs/examples/wasm_emscripten
+        run: |
+          ls -lh target/wasm32-unknown-emscripten/release/
+          test -f target/wasm32-unknown-emscripten/release/fastnoise2_wasm.wasm
+          test -f target/wasm32-unknown-emscripten/release/fastnoise2_wasm.js
+
+      - name: Package WASM demo
+        working-directory: fastnoise2-rs/examples/wasm_emscripten
+        run: |
+          mkdir -p artifact/dist
+          cp index.html artifact/
+          cp target/wasm32-unknown-emscripten/release/fastnoise2_wasm.wasm artifact/dist/
+          cp target/wasm32-unknown-emscripten/release/fastnoise2_wasm.js artifact/dist/
+          ls -lhR artifact/
+
+      - name: Upload WASM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-demo
+          path: fastnoise2-rs/examples/wasm_emscripten/artifact/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Cargo.lock
 **/target
 **/examples_output
+**/dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,213 @@
+# Changelog
+
+All notable changes to fastnoise2-rs will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.0] - 2026-01-14
+
+Updated FastNoise2 C++ submodule from `f8facba` to `cee9ea6`:
+- NewFastSIMD integration with native WASM SIMD128 support
+- Cellular lookup metadata fixes
+- Optional clamping for Remap node output
+
+### Added
+
+- New generator types:
+  - `PingPong<S, P>` - Standalone modifier that bounces values between -1 and 1
+    - Creates flowing contour-like patterns
+    - `P` is hybrid: can be constant or generator-driven strength
+  - `Abs<S>` - Returns absolute value of source output
+    - Useful for creating ridge-like effects from bipolar noise
+  - `SignedSquareRoot<S>` - Square root that preserves sign
+    - Compresses high values more than low values
+  - `DomainRotatePlane<S>` - Optimized rotation for reducing axis-aligned artifacts
+    - Faster than general `DomainRotate` for common use cases
+  - `DomainWarpSimplex<S, A>` - Simplex-based domain warping
+    - Smoother than gradient-based warping
+  - `DomainWarpSuperSimplex<S, A>` - Higher quality simplex domain warping
+    - Better quality but slower than `DomainWarpSimplex`
+  - `Modulus<Lhs, Rhs>` - Floating-point modulo operator
+    - Both sides are hybrid: can be constants or generators
+
+- New enums:
+  - `PlaneRotationType`
+    - `ImproveXYPlanes` - optimizes for top-down 2D views
+    - `ImproveXZPlanes` - optimizes for side-view terrain
+  - `VectorizationScheme`
+    - Controls how simplex domain warp calculates displacement vectors
+    - `OrthogonalGradientMatrix` (default) vs `GradientOuterProduct`
+  - `DistanceFunction::Minkowski`
+    - Generalized distance metric controlled by `minkowski_p` parameter
+    - p=1 gives Manhattan, p=2 gives Euclidean, fractional values give interesting shapes
+
+- Generator parameter enhancements (all via builder methods for backward compatibility):
+  - `Perlin` & `Value`:
+    - Added `feature_scale`, `seed_offset`, `output_min`, `output_max` fields
+    - Feature scale is effectively 1/frequency - higher values produce larger features
+    - Builder methods: `.with_feature_scale()`, `.with_seed_offset()`, `.with_output_range()`
+    - Defaults: feature_scale=100.0, seed_offset=0, output_range=(-1.0, 1.0)
+  - `Simplex` & `SuperSimplex`:
+    - Added `seed_offset`, `output_min`, `output_max` fields
+    - Builder methods: `.with_feature_scale()`, `.with_seed_offset()`, `.with_output_range()`
+    - Kept feature_scale default at 1.0 for backward compatibility
+  - `White`:
+    - Added `seed_offset`, `output_min`, `output_max` fields
+    - Builder methods: `.with_seed_offset()`, `.with_output_range()`
+  - `Checkerboard` & `SineWave`:
+    - Added `output_min`, `output_max` fields
+    - Builder methods: `.with_feature_scale()`, `.with_output_range()`
+  - `DistanceToPoint`:
+    - Made point coordinates Hybrid (can be f32 or Generator)
+    - Added `minkowski_p` as Hybrid field (default 1.5)
+    - Builder methods: `.with_point_x/y/z/w()`, `.with_minkowski_p()`
+  - `Remap`:
+    - Added `clamp_output: bool` field
+    - New constructor: `remap_clamped(from_min, from_max, to_min, to_max, clamp_output)`
+    - Existing `remap()` defaults to no clamping (backwards compatible)
+  - `Cellular` types (`CellularValue`, `CellularDistance`, `CellularLookup`):
+    - Added `minkowski_p` and `size_jitter` hybrid parameters
+    - `minkowski_p` - controls Minkowski distance function shape (1=Manhattan, 2=Euclidean)
+    - `size_jitter` - randomizes cell sizes for more organic look
+
+- Native WASM SIMD128 support via NewFastSIMD integration
+
+### Changed
+
+- Renamed types:
+  - `OpenSimplex2` → `SuperSimplex`
+    - K.jpg's improved simplex variant
+    - The "Open" prefix was dropped upstream for clarity
+  - `opensimplex2()` → `supersimplex()`
+    - Function rename to match type
+  - `PositionOutput` → `Gradient`
+    - Better describes what it does: outputs linear gradient based on position
+  - `SquareRoot` → `SignedSquareRoot`
+    - Clarifies that it preserves sign (sqrt of abs value, then restores sign)
+
+- Renamed fields (aligning with upstream C++ API):
+  - `DomainScale`: `scale` → `scaling`
+  - `DomainAxisScale`: `scale_x/y/z/w` → `scaling_x/y/z/w`
+  - `Terrace`: `multiplier` → `step_count`
+    - Clarifies meaning: higher value = more steps = smaller terraces
+  - `CellularValue/Distance/Lookup`: `jitter_modifier` → `grid_jitter`
+    - More descriptive: controls how much cells deviate from grid
+  - `DomainWarpGradient`: `warp_frequency` → `feature_scale`
+    - Consistent with other noise types
+
+- Struct signature changes:
+  - `Simplex`:
+    - Was unit struct, now has `feature_scale`, `seed_offset`, `output_min`, `output_max`
+    - Feature scale is effectively 1/frequency - higher = larger features
+  - `SuperSimplex`:
+    - Now has `feature_scale`, `seed_offset`, `output_min`, `output_max` fields
+  - `Terrace<S>` → `Terrace<S, Sm>`:
+    - Smoothness is now Hybrid (can be f32 or Generator)
+    - Enables spatially-varying smoothness: sharp terraces in some areas, smooth in others
+    - Backwards compatible: `terrace(4.0, 0.5)` still works
+  - `CellularValue<J>` → `CellularValue<J, M, S>`
+  - `CellularDistance<J>` → `CellularDistance<J, M, S>`
+  - `CellularLookup<L, J>` → `CellularLookup<L, J, M, S>`
+
+### Removed
+
+- `FractalPingPong`
+  - Ping-pong is now a standalone modifier `PingPong<S, P>` instead of a fractal type
+  - More flexible: can be applied to any generator, not just fractals
+- `OpenSimplex2S`
+  - Was the "smooth" variant, now consolidated into `SuperSimplex`
+
+### Fixed
+
+- Cellular lookup metadata parent class inheritance
+
+---
+
+## Migration Guide
+
+### Type Renames
+
+```rust
+// Old
+OpenSimplex2
+opensimplex2()
+PositionOutput { ... }
+SquareRoot { source }
+
+// New
+SuperSimplex { feature_scale: 1.0, ..Default::default() }
+supersimplex()
+Gradient { ... }
+SignedSquareRoot { source }
+```
+
+### Field Renames
+
+```rust
+// Old
+DomainScale { source, scale: 2.0 }
+Terrace { source, multiplier: 4.0, smoothness: 0.5 }
+CellularValue { jitter_modifier: 1.0, ... }
+
+// New
+DomainScale { source, scaling: 2.0 }
+Terrace { source, step_count: 4.0, smoothness: 0.5 }
+CellularValue { grid_jitter: 1.0, minkowski_p: 2.0, size_jitter: 0.0, ... }
+```
+
+### Struct Initialization
+
+```rust
+// Old - unit struct
+Simplex
+
+// New - use Default for optional fields
+Simplex::default()
+simplex()  // helper function still works
+```
+
+### Builder Pattern Usage
+
+```rust
+// Simple (backward compatible)
+perlin()
+simplex()
+white()
+
+// With customization
+perlin()
+    .with_feature_scale(50.0)
+    .with_seed_offset(42)
+    .with_output_range(0.0, 1.0)
+
+simplex()
+    .with_feature_scale(0.5)
+    .with_output_range(-0.5, 0.5)
+
+// Generator-driven parameters
+distance_to_point(DistanceFunction::Euclidean, [0.0, 0.0, 0.0, 0.0])
+    .with_point_x(simplex())  // moving point!
+    .with_minkowski_p(2.0)
+
+terrace(4.0, simplex())  // spatially-varying smoothness
+```
+
+### FractalPingPong Migration
+
+```rust
+// Old - dedicated fractal type
+FractalPingPong { source, octaves: 4, ... }
+
+// New - composable modifier
+fractal_fbm(perlin(), 4)
+    .ping_pong(2.0)  // apply ping-pong as modifier
+```
+
+---
+
+## Upstream Reference
+
+FastNoise2 C++ version: `cee9ea69c00c6e83b57072831063dbe7e4234b03`
+
+[0.4.0]: https://github.com/Aidenwebb/fastnoise2-rs/compare/v0.3.1...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,5 +209,3 @@ fractal_fbm(perlin(), 4)
 ## Upstream Reference
 
 FastNoise2 C++ version: `cee9ea69c00c6e83b57072831063dbe7e4234b03`
-
-[0.4.0]: https://github.com/Aidenwebb/fastnoise2-rs/compare/v0.3.1...v0.4.0

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Here is an example of a encoded node tree, exported by FastNoise2's NoiseTool.
 use fastnoise2::SafeNode;
 
 let (x_size, y_size) = (1000, 1000);
+let step_size = 1.0;
 let encoded_node_tree = "E@BBZEE@BD8JFgIECArXIzwECiQIw/UoPwkuAAE@BJDQAE@BC@AIEAJBwQDZmYmPwsAAIA/HAMAAHBCBA==";
 let node = SafeNode::from_encoded_node_tree(encoded_node_tree).unwrap();
 
@@ -26,12 +27,13 @@ let mut noise_out = vec![0.0; (x_size * y_size) as usize];
 
 let min_max = node.gen_uniform_grid_2d(
     &mut noise_out,
-    -x_size / 2, // x offset
-    -y_size / 2, // y offset
-    x_size,
-    y_size,
-    0.01, // frequency
-    1337, // seed
+    -x_size as f32 / 2.0 * step_size, // x offset
+    -y_size as f32 / 2.0 * step_size, // y offset
+    x_size,                           // x size
+    y_size,                           // y size
+    step_size,                        // x step size
+    step_size,                        // y step size
+    1337,                             // seed
 );
 
 // use `noise_out`!

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Here is an example of a encoded node tree, exported by FastNoise2's NoiseTool.
 use fastnoise2::SafeNode;
 
 let (x_size, y_size) = (1000, 1000);
-let encoded_node_tree = "EQACAAAAAAAgQBAAAAAAQBkAEwDD9Sg/DQAEAAAAAAAgQAkAAGZmJj8AAAAAPwEEAAAAAAAAAEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM3MTD4AMzMzPwAAAAA/";
+let encoded_node_tree = "E@BBZEE@BD8JFgIECArXIzwECiQIw/UoPwkuAAE@BJDQAE@BC@AIEAJBwQDZmYmPwsAAIA/HAMAAHBCBA==";
 let node = SafeNode::from_encoded_node_tree(encoded_node_tree).unwrap();
 
 // Allocate a buffer of enough size to hold all output data.

--- a/fastnoise2-rs/examples/encoded_node_tree.rs
+++ b/fastnoise2-rs/examples/encoded_node_tree.rs
@@ -27,7 +27,7 @@ fn main() {
     // Modifying parameters directly using `Node::set` can introduce the same risks as manually building the node tree.
     // Issues might arise due to incorrect parameter types, missing members, or other configuration errors.
     // Ensure that all modifications are valid and consult the FastNoise2 documentation for guidance on parameter types and expected values.
-    let step_size = 0.02;
+    let step_size = 1.0;
     let min_max = node.gen_uniform_grid_2d(
         &mut noise,
         -X_SIZE as f32 / 2.0 * step_size, // x_offset

--- a/fastnoise2-rs/examples/encoded_node_tree.rs
+++ b/fastnoise2-rs/examples/encoded_node_tree.rs
@@ -5,15 +5,13 @@ use fastnoise2::SafeNode;
 use image::{GrayImage, Luma};
 
 // "Simple Terrain" tree integrated into NoiseTool.
-const DEFAULT_ENCODED_NODE_TREE: &str = "EQACAAAAAAAgQBAAAAAAQBkAEwDD9Sg/DQAEAAAAAAAgQAkAAGZmJj8AAAAAPwEEAAAAAAAAAEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM3MTD4AMzMzPwAAAAA/";
+const DEFAULT_ENCODED_NODE_TREE: &str = "E@BBZEE@BD8JFgIECArXIzwECiQIw/UoPwkuAAE@BJDQAE@BC@AIEAJBwQDZmYmPwsAAIA/HAMAAHBCBA==";
 const X_SIZE: i32 = 1024;
 const Y_SIZE: i32 = 1024;
 
 fn main() {
     let encoded_node_tree = std::env::args().nth(1).unwrap_or_else(|| {
-        println!(
-            "Invalid or unspecified encoded node tree, defaulting to '{DEFAULT_ENCODED_NODE_TREE}'"
-        );
+        println!("Invalid or unspecified encoded node tree, defaulting to '{DEFAULT_ENCODED_NODE_TREE}'");
         DEFAULT_ENCODED_NODE_TREE.to_string()
     });
 
@@ -29,13 +27,15 @@ fn main() {
     // Modifying parameters directly using `Node::set` can introduce the same risks as manually building the node tree.
     // Issues might arise due to incorrect parameter types, missing members, or other configuration errors.
     // Ensure that all modifications are valid and consult the FastNoise2 documentation for guidance on parameter types and expected values.
+    let step_size = 0.02;
     let min_max = node.gen_uniform_grid_2d(
         &mut noise,
-        -X_SIZE / 2,
-        -Y_SIZE / 2,
-        X_SIZE,
-        Y_SIZE,
-        0.02,
+        -X_SIZE as f32 / 2.0 * step_size, // x_offset
+        -Y_SIZE as f32 / 2.0 * step_size, // y_offset
+        X_SIZE,                           // x_count
+        Y_SIZE,                           // y_count
+        step_size,                        // x_step_size
+        step_size,                        // y_step_size
         1337,
     );
     let elapsed = start.elapsed();
@@ -63,9 +63,7 @@ fn main() {
 }
 
 fn save(img: GrayImage, filename: &str) {
-    let output_dir =
-        std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default())
-            .join("examples_output");
+    let output_dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default()).join("examples_output");
     std::fs::create_dir_all(&output_dir).expect("Failed to create directories");
     let output_path = output_dir.join(filename);
     img.save(&output_path).expect("Failed to save image");

--- a/fastnoise2-rs/examples/manual.rs
+++ b/fastnoise2-rs/examples/manual.rs
@@ -44,14 +44,16 @@ fn main() {
     // - Internal errors or limitations in the FastNoise2 library that may not be evident from Rust's type safety
     //   or runtime checks.
     // Verify that all node configurations and parameters are correct.
+    let step_size = 0.02;
     let min_max = unsafe {
         node.gen_uniform_grid_2d_unchecked(
             &mut noise,
-            -X_SIZE / 2,
-            -Y_SIZE / 2,
-            X_SIZE,
-            Y_SIZE,
-            0.02,
+            -X_SIZE as f32 / 2.0 * step_size, // x_offset
+            -Y_SIZE as f32 / 2.0 * step_size, // y_offset
+            X_SIZE,                           // x_count
+            Y_SIZE,                           // y_count
+            step_size,                        // x_step_size
+            step_size,                        // y_step_size
             1337,
         )
     };
@@ -80,9 +82,7 @@ fn main() {
 }
 
 fn save(img: GrayImage, filename: &str) {
-    let output_dir =
-        std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default())
-            .join("examples_output");
+    let output_dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default()).join("examples_output");
     std::fs::create_dir_all(&output_dir).expect("Failed to create directories");
     let output_path = output_dir.join(filename);
     img.save(&output_path).expect("Failed to save image");

--- a/fastnoise2-rs/examples/manual.rs
+++ b/fastnoise2-rs/examples/manual.rs
@@ -44,7 +44,7 @@ fn main() {
     // - Internal errors or limitations in the FastNoise2 library that may not be evident from Rust's type safety
     //   or runtime checks.
     // Verify that all node configurations and parameters are correct.
-    let step_size = 0.02;
+    let step_size = 1.0;
     let min_max = unsafe {
         node.gen_uniform_grid_2d_unchecked(
             &mut noise,

--- a/fastnoise2-rs/examples/multithreaded.rs
+++ b/fastnoise2-rs/examples/multithreaded.rs
@@ -1,7 +1,7 @@
 use fastnoise2::SafeNode;
 
 fn main() {
-    let node = SafeNode::from_encoded_node_tree("EQACAAAAAAAgQBAAAAAAQBkAEwDD9Sg/DQAEAAAAAAAgQAkAAGZmJj8AAAAAPwEEAAAAAAAAAEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM3MTD4AMzMzPwAAAAA/").unwrap();
+    let node = SafeNode::from_encoded_node_tree("E@BBZEE@BD8JFgIECArXIzwECiQIw/UoPwkuAAE@BJDQAE@BC@AIEAJBwQDZmYmPwsAAIA/HAMAAHBCBA==").unwrap();
 
     // A SafeNode is an Arc wrapping a Node. Thus, cloning a SafeNode does not reinstantiate it.
     let n1 = node.clone();

--- a/fastnoise2-rs/examples/safe.rs
+++ b/fastnoise2-rs/examples/safe.rs
@@ -23,8 +23,8 @@ fn create_node() -> GeneratorWrapper<SafeNode> {
     // that FastNoise2 handles differently. It is also easier to write "0.5".
     let _n = Add {
         lhs: Fade {
-            a: SineWave { feature_scale: 0.1 },
-            b: SineWave { feature_scale: -0.2 },
+            a: SineWave { feature_scale: 0.1, ..Default::default() },
+            b: SineWave { feature_scale: -0.2, ..Default::default() },
             fade: Simplex::default(),
             fade_min: -1.0,
             fade_max: 1.0,
@@ -35,8 +35,8 @@ fn create_node() -> GeneratorWrapper<SafeNode> {
 
     let _n = Add {
         lhs: Fade {
-            a: SineWave { feature_scale: 0.1 },
-            b: SineWave { feature_scale: -0.2 },
+            a: SineWave { feature_scale: 0.1, ..Default::default() },
+            b: SineWave { feature_scale: -0.2, ..Default::default() },
             fade: Simplex::default(),
             fade_min: -1.0,
             fade_max: 1.0,
@@ -51,7 +51,7 @@ fn create_node() -> GeneratorWrapper<SafeNode> {
 
     // You can also mix the two writings. Note the use of the GeneratorWrapper type to enable use of the operator
     let _n = GeneratorWrapper(Fade {
-        a: SineWave { feature_scale: 0.1 },
+        a: SineWave { feature_scale: 0.1, ..Default::default() },
         b: sinewave(-0.2),
         fade: Simplex::default(),
         fade_min: -1.0,

--- a/fastnoise2-rs/examples/safe_simple_terrain.rs
+++ b/fastnoise2-rs/examples/safe_simple_terrain.rs
@@ -8,11 +8,10 @@ const X_SIZE: i32 = 1024;
 const Y_SIZE: i32 = 1024;
 
 fn create_node() -> GeneratorWrapper<SafeNode> {
-    (opensimplex2().fbm(0.65, 0.5, 4, 2.5).domain_scale(0.66)
-        + position_output([0.0, 3.0, 0.0, 0.0], [0.0; 4]))
-    .domain_warp_gradient(0.2, 2.0)
-    .domain_warp_progressive(0.7, 0.5, 2, 2.5)
-    .build()
+    (supersimplex().fbm(0.65, 0.5, 4, 2.5).domain_scale(0.66) + gradient([0.0, 3.0, 0.0, 0.0], [0.0; 4]))
+        .domain_warp_gradient(0.2, 2.0)
+        .domain_warp_progressive(0.7, 0.5, 2, 2.5)
+        .build()
 }
 
 fn main() {
@@ -21,14 +20,16 @@ fn main() {
 
     let mut noise = vec![0.0; (X_SIZE * Y_SIZE) as usize];
 
+    let step_size = 0.02;
     let start = Instant::now();
     let min_max = node.gen_uniform_grid_2d(
         &mut noise,
-        -X_SIZE / 2,
-        -Y_SIZE / 2,
-        X_SIZE,
-        Y_SIZE,
-        0.02,
+        -X_SIZE as f32 / 2.0 * step_size, // x_offset
+        -Y_SIZE as f32 / 2.0 * step_size, // y_offset
+        X_SIZE,                           // x_count
+        Y_SIZE,                           // y_count
+        step_size,                        // x_step_size
+        step_size,                        // y_step_size
         1337,
     );
     let elapsed = start.elapsed();
@@ -56,9 +57,7 @@ fn main() {
 }
 
 fn save(img: GrayImage, filename: &str) {
-    let output_dir =
-        std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default())
-            .join("examples_output");
+    let output_dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default()).join("examples_output");
     std::fs::create_dir_all(&output_dir).expect("Failed to create directories");
     let output_path = output_dir.join(filename);
     img.save(&output_path).expect("Failed to save image");

--- a/fastnoise2-rs/examples/wasm_emscripten/Cargo.toml
+++ b/fastnoise2-rs/examples/wasm_emscripten/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fastnoise2-wasm-emscripten"
+version = "0.1.0"
+edition = "2021"
+
+# Exclude from parent workspace
+[workspace]
+
+# Build as binary for emscripten target to generate JS glue code
+[[bin]]
+name = "fastnoise2_wasm"
+path = "src/main.rs"
+
+[dependencies]
+fastnoise2 = { path = "../.." }
+
+[profile.release]
+opt-level = "s"
+lto = true

--- a/fastnoise2-rs/examples/wasm_emscripten/Makefile
+++ b/fastnoise2-rs/examples/wasm_emscripten/Makefile
@@ -1,0 +1,44 @@
+# FastNoise2 WASM Demo - Emscripten Build
+#
+# Requires:
+#   - Emscripten SDK (source ~/emsdk/emsdk_env.sh)
+#   - rustup target add wasm32-unknown-emscripten
+#
+# Usage:
+#   make build   - Build the WASM module
+#   make serve   - Start a local web server
+#   make clean   - Clean build artifacts
+
+.PHONY: build serve clean
+
+# Emscripten compiler flags for linking
+EMCC_CFLAGS = \
+	-s MODULARIZE=1 \
+	-s EXPORT_NAME=createFastNoise2Module \
+	-s EXPORTED_FUNCTIONS=_generate_noise,_malloc,_free,_main \
+	-s EXPORTED_RUNTIME_METHODS=HEAPU8 \
+	-s ALLOW_MEMORY_GROWTH=1 \
+	-s ERROR_ON_UNDEFINED_SYMBOLS=0 \
+	-O3
+
+build:
+	@echo "Building FastNoise2 WASM with Emscripten target..."
+	@echo "Make sure you have sourced emsdk_env.sh first!"
+	EMCC_CFLAGS="$(EMCC_CFLAGS)" cargo build --release --target wasm32-unknown-emscripten
+	@echo ""
+	@echo "Copying output files to ./dist/"
+	@mkdir -p dist
+	@cp target/wasm32-unknown-emscripten/release/fastnoise2_wasm.js dist/
+	@cp target/wasm32-unknown-emscripten/release/fastnoise2_wasm.wasm dist/
+	@echo "Build complete!"
+	@echo ""
+	@ls -lh dist/
+
+serve:
+	@echo "Starting web server at http://localhost:8080"
+	@echo "Open index.html in your browser"
+	python3 -m http.server 8080
+
+clean:
+	cargo clean
+	rm -rf dist/

--- a/fastnoise2-rs/examples/wasm_emscripten/README.md
+++ b/fastnoise2-rs/examples/wasm_emscripten/README.md
@@ -23,12 +23,6 @@ make serve
 # Open http://localhost:8080
 ```
 
-By default, prebuilt FastNoise2 binaries are downloaded. To build FastNoise2 from source:
-
-```bash
-FASTNOISE2_BUILD_WASM_FROM_SOURCE=1 make build
-```
-
 ## Files
 
 - `src/main.rs` - Rust code exposing noise generation to JS

--- a/fastnoise2-rs/examples/wasm_emscripten/README.md
+++ b/fastnoise2-rs/examples/wasm_emscripten/README.md
@@ -1,0 +1,36 @@
+# FastNoise2 WASM Demo
+
+Interactive browser demo using FastNoise2 compiled to WebAssembly.
+
+## Why Emscripten?
+
+FastNoise2 is a C++ library. `wasm32-unknown-unknown` targets pure Rust only—no C++ compiler, no libc, no stdlib.
+
+Emscripten is required to:
+- Compile FastNoise2's C++ code to WASM
+- Provide libc++ runtime
+- Enable WASM SIMD128 via FastSIMD's native support
+
+## Quick Start
+
+```bash
+# Install Emscripten SDK (https://emscripten.org/docs/getting_started)
+source ~/emsdk/emsdk_env.sh
+rustup target add wasm32-unknown-emscripten
+
+make build
+make serve
+# Open http://localhost:8080
+```
+
+By default, prebuilt FastNoise2 binaries are downloaded. To build FastNoise2 from source:
+
+```bash
+FASTNOISE2_BUILD_WASM_FROM_SOURCE=1 make build
+```
+
+## Files
+
+- `src/main.rs` - Rust code exposing noise generation to JS
+- `index.html` - Interactive demo with canvas visualization
+- `Makefile` - Build commands

--- a/fastnoise2-rs/examples/wasm_emscripten/index.html
+++ b/fastnoise2-rs/examples/wasm_emscripten/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>FastNoise2 WASM</title>
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #111;
+    }
+    canvas {
+      image-rendering: pixelated;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="canvas" width="512" height="512"></canvas>
+  <script src="dist/fastnoise2_wasm.js"></script>
+  <script>
+    createFastNoise2Module().then(Module => {
+      const canvas = document.getElementById('canvas');
+      const ctx = canvas.getContext('2d');
+      const { width, height } = canvas;
+      const size = width * height;
+
+      const ptr = Module._malloc(size);
+      Module._generate_noise(ptr, width, height);
+
+      const data = Module.HEAPU8.subarray(ptr, ptr + size);
+      const img = ctx.createImageData(width, height);
+      for (let i = 0; i < size; i++) {
+        const v = data[i];
+        img.data[i * 4] = v;
+        img.data[i * 4 + 1] = v;
+        img.data[i * 4 + 2] = v;
+        img.data[i * 4 + 3] = 255;
+      }
+      ctx.putImageData(img, 0, 0);
+      Module._free(ptr);
+    });
+  </script>
+</body>
+</html>

--- a/fastnoise2-rs/examples/wasm_emscripten/src/main.rs
+++ b/fastnoise2-rs/examples/wasm_emscripten/src/main.rs
@@ -1,0 +1,27 @@
+//! FastNoise2 WASM Demo - Simple noise visualization
+
+use fastnoise2::generator::prelude::*;
+use fastnoise2::SafeNode;
+
+/// Generate 2D noise and write grayscale values (0-255) to output buffer
+#[no_mangle]
+pub extern "C" fn generate_noise(output: *mut u8, width: i32, height: i32) {
+    let size = (width * height) as usize;
+    let node: GeneratorWrapper<SafeNode> = simplex().fbm(0.5, 0.0, 4, 2.0).build();
+
+    let mut float_output = vec![0.0f32; size];
+    node.gen_uniform_grid_2d(
+        &mut float_output,
+        0.0, 0.0,
+        width, height,
+        0.01, 0.01,
+        1337,
+    );
+
+    let output_slice = unsafe { std::slice::from_raw_parts_mut(output, size) };
+    for (i, &v) in float_output.iter().enumerate() {
+        output_slice[i] = ((v + 1.0) * 0.5 * 255.0).clamp(0.0, 255.0) as u8;
+    }
+}
+
+fn main() {}

--- a/fastnoise2-rs/src/generator/basic.rs
+++ b/fastnoise2-rs/src/generator/basic.rs
@@ -1,22 +1,43 @@
-use super::{DistanceFunction, Generator, GeneratorWrapper};
+use super::{DistanceFunction, Generator, GeneratorWrapper, Hybrid};
 use crate::{safe::SafeNode, Node};
 
+/// Constant value generator.
 #[derive(Clone, Debug)]
 pub struct Constant {
     pub value: f32,
 }
 
+/// White noise generator.
 #[derive(Clone, Debug)]
-pub struct White;
-
-#[derive(Clone, Debug)]
-pub struct Checkerboard {
-    pub size: f32,
+pub struct White {
+    /// Offset applied to the seed. Default: 0
+    pub seed_offset: i32,
+    /// Minimum output value. Default: -1.0
+    pub output_min: f32,
+    /// Maximum output value. Default: 1.0
+    pub output_max: f32,
 }
 
+/// Checkerboard pattern generator.
+#[derive(Clone, Debug)]
+pub struct Checkerboard {
+    /// Feature Scale (effectively 1/frequency). Default: 1.0
+    pub feature_scale: f32,
+    /// Minimum output value. Default: -1.0
+    pub output_min: f32,
+    /// Maximum output value. Default: 1.0
+    pub output_max: f32,
+}
+
+/// Sine wave generator.
 #[derive(Clone, Debug)]
 pub struct SineWave {
+    /// Feature Scale (effectively 1/frequency). Default: 1.0
     pub feature_scale: f32,
+    /// Minimum output value. Default: -1.0
+    pub output_min: f32,
+    /// Maximum output value. Default: 1.0
+    pub output_max: f32,
 }
 
 /// Gradient generator (formerly PositionOutput in older FastNoise2 versions).
@@ -33,13 +54,58 @@ pub struct Gradient {
     pub offset_w: f32,
 }
 
+/// Distance to point generator.
+/// Calculates distance from each point to a target point.
 #[derive(Clone, Debug)]
-pub struct DistanceToPoint {
+pub struct DistanceToPoint<X, Y, Z, W, M>
+where
+    X: Hybrid,
+    Y: Hybrid,
+    Z: Hybrid,
+    W: Hybrid,
+    M: Hybrid,
+{
     pub distance_function: DistanceFunction,
-    pub x_point: f32,
-    pub y_point: f32,
-    pub z_point: f32,
-    pub w_point: f32,
+    /// X coordinate of target point (can be f32 or Generator).
+    pub point_x: X,
+    /// Y coordinate of target point (can be f32 or Generator).
+    pub point_y: Y,
+    /// Z coordinate of target point (can be f32 or Generator).
+    pub point_z: Z,
+    /// W coordinate of target point (can be f32 or Generator).
+    pub point_w: W,
+    /// Minkowski P value for Minkowski distance function. Default: 1.5
+    pub minkowski_p: M,
+}
+
+impl Default for White {
+    fn default() -> Self {
+        Self {
+            seed_offset: 0,
+            output_min: -1.0,
+            output_max: 1.0,
+        }
+    }
+}
+
+impl Default for Checkerboard {
+    fn default() -> Self {
+        Self {
+            feature_scale: 1.0,
+            output_min: -1.0,
+            output_max: 1.0,
+        }
+    }
+}
+
+impl Default for SineWave {
+    fn default() -> Self {
+        Self {
+            feature_scale: 1.0,
+            output_min: -1.0,
+            output_max: 1.0,
+        }
+    }
 }
 
 impl Generator for Constant {
@@ -54,7 +120,11 @@ impl Generator for Constant {
 impl Generator for White {
     #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
     fn build(&self) -> GeneratorWrapper<SafeNode> {
-        SafeNode(Node::from_name("White").unwrap().into()).into()
+        let mut node = Node::from_name("White").unwrap();
+        node.set("SeedOffset", self.seed_offset).unwrap();
+        node.set("OutputMin", self.output_min).unwrap();
+        node.set("OutputMax", self.output_max).unwrap();
+        SafeNode(node.into()).into()
     }
 }
 
@@ -62,7 +132,9 @@ impl Generator for Checkerboard {
     #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
     fn build(&self) -> GeneratorWrapper<SafeNode> {
         let mut node = Node::from_name("Checkerboard").unwrap();
-        node.set("FeatureScale", self.size).unwrap();
+        node.set("FeatureScale", self.feature_scale).unwrap();
+        node.set("OutputMin", self.output_min).unwrap();
+        node.set("OutputMax", self.output_max).unwrap();
         SafeNode(node.into()).into()
     }
 }
@@ -72,6 +144,8 @@ impl Generator for SineWave {
     fn build(&self) -> GeneratorWrapper<SafeNode> {
         let mut node = Node::from_name("SineWave").unwrap();
         node.set("FeatureScale", self.feature_scale).unwrap();
+        node.set("OutputMin", self.output_min).unwrap();
+        node.set("OutputMax", self.output_max).unwrap();
         SafeNode(node.into()).into()
     }
 }
@@ -92,32 +166,45 @@ impl Generator for Gradient {
     }
 }
 
-impl Generator for DistanceToPoint {
+impl<X, Y, Z, W, M> Generator for DistanceToPoint<X, Y, Z, W, M>
+where
+    X: Hybrid,
+    Y: Hybrid,
+    Z: Hybrid,
+    W: Hybrid,
+    M: Hybrid,
+{
     #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
     fn build(&self) -> GeneratorWrapper<SafeNode> {
         let mut node = Node::from_name("DistanceToPoint").unwrap();
         node.set("DistanceFunction", &*self.distance_function.to_string()).unwrap();
-        node.set("PointX", self.x_point).unwrap();
-        node.set("PointY", self.y_point).unwrap();
-        node.set("PointZ", self.z_point).unwrap();
-        node.set("PointW", self.w_point).unwrap();
+        node.set("PointX", self.point_x.clone()).unwrap();
+        node.set("PointY", self.point_y.clone()).unwrap();
+        node.set("PointZ", self.point_z.clone()).unwrap();
+        node.set("PointW", self.point_w.clone()).unwrap();
+        node.set("MinkowskiP", self.minkowski_p.clone()).unwrap();
         SafeNode(node.into()).into()
     }
 }
 
+/// Creates a constant value generator.
 pub fn constant(value: f32) -> GeneratorWrapper<Constant> {
     Constant { value }.into()
 }
 
+/// Creates a white noise generator with default parameters.
 pub fn white() -> GeneratorWrapper<White> {
-    White.into()
+    White::default().into()
 }
 
-pub fn checkerboard(size: f32) -> GeneratorWrapper<Checkerboard> {
-    Checkerboard { size }.into()
+/// Creates a checkerboard pattern generator with the given feature scale.
+pub fn checkerboard(feature_scale: f32) -> GeneratorWrapper<Checkerboard> {
+    Checkerboard { feature_scale, ..Default::default() }.into()
 }
+
+/// Creates a sine wave generator with the given feature scale.
 pub fn sinewave(feature_scale: f32) -> GeneratorWrapper<SineWave> {
-    SineWave { feature_scale }.into()
+    SineWave { feature_scale, ..Default::default() }.into()
 }
 
 /// Creates a Gradient generator with the given multipliers and offsets.
@@ -137,14 +224,132 @@ pub fn gradient(multiplier: [f32; 4], offset: [f32; 4]) -> GeneratorWrapper<Grad
     .into()
 }
 
-pub fn distance_to_point(distance_function: DistanceFunction, point: [f32; 4]) -> GeneratorWrapper<DistanceToPoint> {
-    let [x_point, y_point, z_point, w_point] = point;
+/// Creates a distance to point generator with f32 coordinates and default minkowski_p.
+pub fn distance_to_point(distance_function: DistanceFunction, point: [f32; 4]) -> GeneratorWrapper<DistanceToPoint<f32, f32, f32, f32, f32>> {
+    let [point_x, point_y, point_z, point_w] = point;
     DistanceToPoint {
         distance_function,
-        x_point,
-        y_point,
-        z_point,
-        w_point,
+        point_x,
+        point_y,
+        point_z,
+        point_w,
+        minkowski_p: 1.5,
     }
     .into()
+}
+
+// Builder methods for White
+impl GeneratorWrapper<White> {
+    /// Sets the seed offset for variation.
+    pub fn with_seed_offset(mut self, offset: i32) -> Self {
+        self.0.seed_offset = offset;
+        self
+    }
+
+    /// Sets the output range.
+    pub fn with_output_range(mut self, min: f32, max: f32) -> Self {
+        self.0.output_min = min;
+        self.0.output_max = max;
+        self
+    }
+}
+
+// Builder methods for Checkerboard
+impl GeneratorWrapper<Checkerboard> {
+    /// Sets the feature scale (effectively 1/frequency).
+    pub fn with_feature_scale(mut self, scale: f32) -> Self {
+        self.0.feature_scale = scale;
+        self
+    }
+
+    /// Sets the output range.
+    pub fn with_output_range(mut self, min: f32, max: f32) -> Self {
+        self.0.output_min = min;
+        self.0.output_max = max;
+        self
+    }
+}
+
+// Builder methods for SineWave
+impl GeneratorWrapper<SineWave> {
+    /// Sets the feature scale (effectively 1/frequency).
+    pub fn with_feature_scale(mut self, scale: f32) -> Self {
+        self.0.feature_scale = scale;
+        self
+    }
+
+    /// Sets the output range.
+    pub fn with_output_range(mut self, min: f32, max: f32) -> Self {
+        self.0.output_min = min;
+        self.0.output_max = max;
+        self
+    }
+}
+
+// Builder methods for DistanceToPoint with f32 coordinates
+impl GeneratorWrapper<DistanceToPoint<f32, f32, f32, f32, f32>> {
+    /// Sets the minkowski P value for Minkowski distance function.
+    pub fn with_minkowski_p<M: Hybrid>(self, minkowski_p: M) -> GeneratorWrapper<DistanceToPoint<f32, f32, f32, f32, M>> {
+        DistanceToPoint {
+            distance_function: self.0.distance_function,
+            point_x: self.0.point_x,
+            point_y: self.0.point_y,
+            point_z: self.0.point_z,
+            point_w: self.0.point_w,
+            minkowski_p,
+        }
+        .into()
+    }
+
+    /// Sets the X coordinate of the target point (can be f32 or Generator).
+    pub fn with_point_x<X: Hybrid>(self, point_x: X) -> GeneratorWrapper<DistanceToPoint<X, f32, f32, f32, f32>> {
+        DistanceToPoint {
+            distance_function: self.0.distance_function,
+            point_x,
+            point_y: self.0.point_y,
+            point_z: self.0.point_z,
+            point_w: self.0.point_w,
+            minkowski_p: self.0.minkowski_p,
+        }
+        .into()
+    }
+
+    /// Sets the Y coordinate of the target point (can be f32 or Generator).
+    pub fn with_point_y<Y: Hybrid>(self, point_y: Y) -> GeneratorWrapper<DistanceToPoint<f32, Y, f32, f32, f32>> {
+        DistanceToPoint {
+            distance_function: self.0.distance_function,
+            point_x: self.0.point_x,
+            point_y,
+            point_z: self.0.point_z,
+            point_w: self.0.point_w,
+            minkowski_p: self.0.minkowski_p,
+        }
+        .into()
+    }
+
+    /// Sets the Z coordinate of the target point (can be f32 or Generator).
+    pub fn with_point_z<Z: Hybrid>(self, point_z: Z) -> GeneratorWrapper<DistanceToPoint<f32, f32, Z, f32, f32>> {
+        DistanceToPoint {
+            distance_function: self.0.distance_function,
+            point_x: self.0.point_x,
+            point_y: self.0.point_y,
+            point_z,
+            point_w: self.0.point_w,
+            minkowski_p: self.0.minkowski_p,
+        }
+        .into()
+    }
+
+    /// Sets the W coordinate of the target point (can be f32 or Generator).
+    pub fn with_point_w<W: Hybrid>(self, point_w: W) -> GeneratorWrapper<DistanceToPoint<f32, f32, f32, W, f32>> {
+        DistanceToPoint {
+            distance_function: self.0.distance_function,
+            point_x: self.0.point_x,
+            point_y: self.0.point_y,
+            point_z: self.0.point_z,
+            point_w,
+            minkowski_p: self.0.minkowski_p,
+        }
+        .into()
+    }
 }

--- a/fastnoise2-rs/src/generator/cellular.rs
+++ b/fastnoise2-rs/src/generator/cellular.rs
@@ -1,145 +1,232 @@
+use super::{DistanceFunction, Generator, GeneratorWrapper, Hybrid};
 use crate::{safe::SafeNode, Node};
 
-use super::{DistanceFunction, Generator, GeneratorWrapper, Hybrid};
-
 #[derive(Clone, Debug)]
-pub struct CellularValue<J>
+pub struct CellularValue<J, M, S>
 where
     J: Hybrid,
+    M: Hybrid,
+    S: Hybrid,
 {
-    pub jitter_modifier: J,
+    pub grid_jitter: J,
     pub distance_function: DistanceFunction,
     pub value_index: i32,
+    pub minkowski_p: M,
+    pub size_jitter: S,
 }
 
 #[derive(Clone, Debug)]
-pub struct CellularDistance<J>
+pub struct CellularDistance<J, M, S>
 where
     J: Hybrid,
+    M: Hybrid,
+    S: Hybrid,
 {
-    pub jitter_modifier: J,
+    pub grid_jitter: J,
     pub distance_function: DistanceFunction,
     pub distance_index_0: i32,
     pub distance_index_1: i32,
     pub return_type: CellularDistanceReturnType,
+    pub minkowski_p: M,
+    pub size_jitter: S,
 }
 
 #[derive(Clone, Debug)]
-pub struct CellularLookup<L, J>
+pub struct CellularLookup<L, J, M, S>
 where
     L: Generator,
     J: Hybrid,
+    M: Hybrid,
+    S: Hybrid,
 {
     pub lookup: L,
-    pub jitter_modifier: J,
+    pub grid_jitter: J,
     pub distance_function: DistanceFunction,
-    pub lookup_frequency: f32,
+    pub minkowski_p: M,
+    pub size_jitter: S,
 }
 
-impl<J> Generator for CellularValue<J>
+impl<J, M, S> Generator for CellularValue<J, M, S>
 where
     J: Hybrid,
+    M: Hybrid,
+    S: Hybrid,
 {
     #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
     fn build(&self) -> GeneratorWrapper<SafeNode> {
         let mut node = Node::from_name("CellularValue").unwrap();
-        node.set("JitterModifier", self.jitter_modifier.clone())
-            .unwrap();
-        node.set("DistanceFunction", &*self.distance_function.to_string())
-            .unwrap();
+        node.set("GridJitter", self.grid_jitter.clone()).unwrap();
+        node.set("DistanceFunction", &*self.distance_function.to_string()).unwrap();
         node.set("ValueIndex", self.value_index).unwrap();
+        node.set("MinkowskiP", self.minkowski_p.clone()).unwrap();
+        node.set("SizeJitter", self.size_jitter.clone()).unwrap();
         SafeNode(node.into()).into()
     }
 }
 
-impl<J> Generator for CellularDistance<J>
+impl<J, M, S> Generator for CellularDistance<J, M, S>
 where
     J: Hybrid,
+    M: Hybrid,
+    S: Hybrid,
 {
     #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
     fn build(&self) -> GeneratorWrapper<SafeNode> {
         let mut node = Node::from_name("CellularDistance").unwrap();
-        node.set("JitterModifier", self.jitter_modifier.clone())
-            .unwrap();
-        node.set("DistanceFunction", &*self.distance_function.to_string())
-            .unwrap();
+        node.set("GridJitter", self.grid_jitter.clone()).unwrap();
+        node.set("DistanceFunction", &*self.distance_function.to_string()).unwrap();
         node.set("DistanceIndex0", self.distance_index_0).unwrap();
         node.set("DistanceIndex1", self.distance_index_1).unwrap();
-        node.set("ReturnType", &*self.return_type.to_string())
-            .unwrap();
+        node.set("ReturnType", &*self.return_type.to_string()).unwrap();
+        node.set("MinkowskiP", self.minkowski_p.clone()).unwrap();
+        node.set("SizeJitter", self.size_jitter.clone()).unwrap();
         SafeNode(node.into()).into()
     }
 }
 
-impl<L, J> Generator for CellularLookup<L, J>
+impl<L, J, M, S> Generator for CellularLookup<L, J, M, S>
 where
     L: Generator,
     J: Hybrid,
+    M: Hybrid,
+    S: Hybrid,
 {
     #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
     fn build(&self) -> GeneratorWrapper<SafeNode> {
         let mut node = Node::from_name("CellularLookup").unwrap();
         node.set("Lookup", &self.lookup).unwrap();
-        node.set("JitterModifier", self.jitter_modifier.clone())
-            .unwrap();
-        node.set("DistanceFunction", &*self.distance_function.to_string())
-            .unwrap();
-        node.set("LookupFrequency", self.lookup_frequency).unwrap();
+        node.set("GridJitter", self.grid_jitter.clone()).unwrap();
+        node.set("DistanceFunction", &*self.distance_function.to_string()).unwrap();
+        node.set("MinkowskiP", self.minkowski_p.clone()).unwrap();
+        node.set("SizeJitter", self.size_jitter.clone()).unwrap();
         SafeNode(node.into()).into()
     }
 }
 
-pub fn cellular_value<J>(
-    jitter_modifier: J,
-    distance_function: DistanceFunction,
-    value_index: i32,
-) -> GeneratorWrapper<CellularValue<J>>
+/// Creates a CellularValue generator with default parameters.
+pub fn cellular_value<J>(grid_jitter: J, distance_function: DistanceFunction, value_index: i32) -> GeneratorWrapper<CellularValue<J, f32, f32>>
 where
     J: Hybrid,
 {
     CellularValue {
-        jitter_modifier,
+        grid_jitter,
         distance_function,
         value_index,
+        minkowski_p: 1.5,
+        size_jitter: 0.0,
     }
     .into()
 }
 
+/// Creates a CellularValue generator with all parameters.
+pub fn cellular_value_full<J, M, S>(
+    grid_jitter: J,
+    distance_function: DistanceFunction,
+    value_index: i32,
+    minkowski_p: M,
+    size_jitter: S,
+) -> GeneratorWrapper<CellularValue<J, M, S>>
+where
+    J: Hybrid,
+    M: Hybrid,
+    S: Hybrid,
+{
+    CellularValue {
+        grid_jitter,
+        distance_function,
+        value_index,
+        minkowski_p,
+        size_jitter,
+    }
+    .into()
+}
+
+/// Creates a CellularDistance generator with default parameters.
 pub fn cellular_distance<J>(
-    jitter_modifier: J,
+    grid_jitter: J,
     distance_function: DistanceFunction,
     distance_index_0: i32,
     distance_index_1: i32,
     return_type: CellularDistanceReturnType,
-) -> GeneratorWrapper<CellularDistance<J>>
+) -> GeneratorWrapper<CellularDistance<J, f32, f32>>
 where
     J: Hybrid,
 {
     CellularDistance {
-        jitter_modifier,
+        grid_jitter,
         distance_function,
         distance_index_0,
         distance_index_1,
         return_type,
+        minkowski_p: 1.5,
+        size_jitter: 0.0,
     }
     .into()
 }
 
-pub fn cellular_lookup<L, J>(
-    lookup: L,
-    jitter_modifier: J,
+/// Creates a CellularDistance generator with all parameters.
+pub fn cellular_distance_full<J, M, S>(
+    grid_jitter: J,
     distance_function: DistanceFunction,
-    lookup_frequency: f32,
-) -> GeneratorWrapper<CellularLookup<L, J>>
+    distance_index_0: i32,
+    distance_index_1: i32,
+    return_type: CellularDistanceReturnType,
+    minkowski_p: M,
+    size_jitter: S,
+) -> GeneratorWrapper<CellularDistance<J, M, S>>
+where
+    J: Hybrid,
+    M: Hybrid,
+    S: Hybrid,
+{
+    CellularDistance {
+        grid_jitter,
+        distance_function,
+        distance_index_0,
+        distance_index_1,
+        return_type,
+        minkowski_p,
+        size_jitter,
+    }
+    .into()
+}
+
+/// Creates a CellularLookup generator with default parameters.
+pub fn cellular_lookup<L, J>(lookup: L, grid_jitter: J, distance_function: DistanceFunction) -> GeneratorWrapper<CellularLookup<L, J, f32, f32>>
 where
     L: Generator,
     J: Hybrid,
 {
     CellularLookup {
         lookup,
-        jitter_modifier,
+        grid_jitter,
         distance_function,
-        lookup_frequency,
+        minkowski_p: 1.5,
+        size_jitter: 0.0,
+    }
+    .into()
+}
+
+/// Creates a CellularLookup generator with all parameters.
+pub fn cellular_lookup_full<L, J, M, S>(
+    lookup: L,
+    grid_jitter: J,
+    distance_function: DistanceFunction,
+    minkowski_p: M,
+    size_jitter: S,
+) -> GeneratorWrapper<CellularLookup<L, J, M, S>>
+where
+    L: Generator,
+    J: Hybrid,
+    M: Hybrid,
+    S: Hybrid,
+{
+    CellularLookup {
+        lookup,
+        grid_jitter,
+        distance_function,
+        minkowski_p,
+        size_jitter,
     }
     .into()
 }

--- a/fastnoise2-rs/src/generator/domain_warp.rs
+++ b/fastnoise2-rs/src/generator/domain_warp.rs
@@ -1,8 +1,26 @@
-use crate::{safe::SafeNode, Node};
+use std::fmt::Display;
 
 use super::{Generator, GeneratorWrapper, Hybrid};
+use crate::{safe::SafeNode, Node};
 
 pub trait DomainWarpNode: Generator {}
+
+/// Vectorization scheme for simplex-based domain warping.
+#[derive(Clone, Debug, Default)]
+pub enum VectorizationScheme {
+    #[default]
+    OrthogonalGradientMatrix,
+    GradientOuterProduct,
+}
+
+impl Display for VectorizationScheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VectorizationScheme::OrthogonalGradientMatrix => f.write_str("Orthogonal Gradient Matrix"),
+            VectorizationScheme::GradientOuterProduct => f.write_str("Gradient Outer Product"),
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct DomainWarpGradient<S, A>
@@ -12,7 +30,33 @@ where
 {
     pub source: S,
     pub warp_amplitude: A,
-    pub warp_frequency: f32,
+    pub feature_scale: f32,
+}
+
+/// Simplex-based domain warping.
+#[derive(Clone, Debug)]
+pub struct DomainWarpSimplex<S, A>
+where
+    S: Generator,
+    A: Hybrid,
+{
+    pub source: S,
+    pub warp_amplitude: A,
+    pub feature_scale: f32,
+    pub vectorization_scheme: VectorizationScheme,
+}
+
+/// Higher quality simplex-based domain warping.
+#[derive(Clone, Debug)]
+pub struct DomainWarpSuperSimplex<S, A>
+where
+    S: Generator,
+    A: Hybrid,
+{
+    pub source: S,
+    pub warp_amplitude: A,
+    pub feature_scale: f32,
+    pub vectorization_scheme: VectorizationScheme,
 }
 
 impl<S, A> Generator for DomainWarpGradient<S, A>
@@ -24,9 +68,8 @@ where
     fn build(&self) -> GeneratorWrapper<SafeNode> {
         let mut node = Node::from_name("DomainWarpGradient").unwrap();
         node.set("Source", &self.source).unwrap();
-        node.set("WarpAmplitude", self.warp_amplitude.clone())
-            .unwrap();
-        node.set("WarpFrequency", self.warp_frequency).unwrap();
+        node.set("WarpAmplitude", self.warp_amplitude.clone()).unwrap();
+        node.set("FeatureScale", self.feature_scale).unwrap();
         SafeNode(node.into()).into()
     }
 }
@@ -38,22 +81,121 @@ where
 {
 }
 
+impl<S, A> Generator for DomainWarpSimplex<S, A>
+where
+    S: Generator,
+    A: Hybrid,
+{
+    #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
+    fn build(&self) -> GeneratorWrapper<SafeNode> {
+        let mut node = Node::from_name("DomainWarpSimplex").unwrap();
+        node.set("Source", &self.source).unwrap();
+        node.set("WarpAmplitude", self.warp_amplitude.clone()).unwrap();
+        node.set("FeatureScale", self.feature_scale).unwrap();
+        node.set("VectorizationScheme", &*self.vectorization_scheme.to_string()).unwrap();
+        SafeNode(node.into()).into()
+    }
+}
+
+impl<S, A> DomainWarpNode for DomainWarpSimplex<S, A>
+where
+    S: Generator,
+    A: Hybrid,
+{
+}
+
+impl<S, A> Generator for DomainWarpSuperSimplex<S, A>
+where
+    S: Generator,
+    A: Hybrid,
+{
+    #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
+    fn build(&self) -> GeneratorWrapper<SafeNode> {
+        let mut node = Node::from_name("DomainWarpSuperSimplex").unwrap();
+        node.set("Source", &self.source).unwrap();
+        node.set("WarpAmplitude", self.warp_amplitude.clone()).unwrap();
+        node.set("FeatureScale", self.feature_scale).unwrap();
+        node.set("VectorizationScheme", &*self.vectorization_scheme.to_string()).unwrap();
+        SafeNode(node.into()).into()
+    }
+}
+
+impl<S, A> DomainWarpNode for DomainWarpSuperSimplex<S, A>
+where
+    S: Generator,
+    A: Hybrid,
+{
+}
+
 impl<S> GeneratorWrapper<S>
 where
     S: Generator,
 {
-    pub fn domain_warp_gradient<A>(
-        self,
-        warp_amplitude: A,
-        warp_frequency: f32,
-    ) -> GeneratorWrapper<DomainWarpGradient<S, A>>
+    pub fn domain_warp_gradient<A>(self, warp_amplitude: A, feature_scale: f32) -> GeneratorWrapper<DomainWarpGradient<S, A>>
     where
         A: Hybrid,
     {
         DomainWarpGradient {
             source: self.0,
             warp_amplitude,
-            warp_frequency,
+            feature_scale,
+        }
+        .into()
+    }
+
+    pub fn domain_warp_simplex<A>(self, warp_amplitude: A, feature_scale: f32) -> GeneratorWrapper<DomainWarpSimplex<S, A>>
+    where
+        A: Hybrid,
+    {
+        DomainWarpSimplex {
+            source: self.0,
+            warp_amplitude,
+            feature_scale,
+            vectorization_scheme: VectorizationScheme::default(),
+        }
+        .into()
+    }
+
+    pub fn domain_warp_simplex_with_scheme<A>(self, warp_amplitude: A, feature_scale: f32, vectorization_scheme: VectorizationScheme) -> GeneratorWrapper<DomainWarpSimplex<S, A>>
+    where
+        A: Hybrid,
+    {
+        DomainWarpSimplex {
+            source: self.0,
+            warp_amplitude,
+            feature_scale,
+            vectorization_scheme,
+        }
+        .into()
+    }
+
+    pub fn domain_warp_super_simplex<A>(self, warp_amplitude: A, feature_scale: f32) -> GeneratorWrapper<DomainWarpSuperSimplex<S, A>>
+    where
+        A: Hybrid,
+    {
+        DomainWarpSuperSimplex {
+            source: self.0,
+            warp_amplitude,
+            feature_scale,
+            vectorization_scheme: VectorizationScheme::default(),
+        }
+        .into()
+    }
+
+    pub fn domain_warp_super_simplex_with_scheme<A>(
+        self,
+        warp_amplitude: A,
+        feature_scale: f32,
+        vectorization_scheme: VectorizationScheme,
+    ) -> GeneratorWrapper<DomainWarpSuperSimplex<S, A>>
+    where
+        A: Hybrid,
+    {
+        DomainWarpSuperSimplex {
+            source: self.0,
+            warp_amplitude,
+            feature_scale,
+            vectorization_scheme,
         }
         .into()
     }

--- a/fastnoise2-rs/src/generator/domain_warp_fractal.rs
+++ b/fastnoise2-rs/src/generator/domain_warp_fractal.rs
@@ -1,6 +1,5 @@
-use crate::{safe::SafeNode, Node};
-
 use super::{domain_warp::DomainWarpNode, Generator, GeneratorWrapper, Hybrid};
+use crate::{safe::SafeNode, Node};
 
 #[derive(Clone, Debug)]
 pub struct DomainWarpFractalProgressive<S, G, W>
@@ -17,7 +16,7 @@ where
 }
 
 #[derive(Clone, Debug)]
-pub struct DomainWarpFractalIndependant<S, G, W>
+pub struct DomainWarpFractalIndependent<S, G, W>
 where
     S: DomainWarpNode,
     G: Hybrid,
@@ -39,18 +38,16 @@ where
     #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
     fn build(&self) -> GeneratorWrapper<SafeNode> {
         let mut node = Node::from_name("DomainWarpFractalProgressive").unwrap();
-        node.set("DomainWarpSource", &self.domain_warp_source)
-            .unwrap();
+        node.set("DomainWarpSource", &self.domain_warp_source).unwrap();
         node.set("Gain", self.gain.clone()).unwrap();
-        node.set("WeightedStrength", self.weighted_strength.clone())
-            .unwrap();
+        node.set("WeightedStrength", self.weighted_strength.clone()).unwrap();
         node.set("Octaves", self.octaves).unwrap();
         node.set("Lacunarity", self.lacunarity).unwrap();
         SafeNode(node.into()).into()
     }
 }
 
-impl<S, G, W> Generator for DomainWarpFractalIndependant<S, G, W>
+impl<S, G, W> Generator for DomainWarpFractalIndependent<S, G, W>
 where
     S: DomainWarpNode,
     G: Hybrid,
@@ -58,12 +55,10 @@ where
 {
     #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
     fn build(&self) -> GeneratorWrapper<SafeNode> {
-        let mut node = Node::from_name("DomainWarpFractalIndependant").unwrap();
-        node.set("DomainWarpSource", &self.domain_warp_source)
-            .unwrap();
+        let mut node = Node::from_name("DomainWarpFractalIndependent").unwrap();
+        node.set("DomainWarpSource", &self.domain_warp_source).unwrap();
         node.set("Gain", self.gain.clone()).unwrap();
-        node.set("WeightedStrength", self.weighted_strength.clone())
-            .unwrap();
+        node.set("WeightedStrength", self.weighted_strength.clone()).unwrap();
         node.set("Octaves", self.octaves).unwrap();
         node.set("Lacunarity", self.lacunarity).unwrap();
         SafeNode(node.into()).into()
@@ -74,13 +69,7 @@ impl<S> GeneratorWrapper<S>
 where
     S: DomainWarpNode,
 {
-    pub fn domain_warp_progressive<G, W>(
-        self,
-        gain: G,
-        weighted_strength: W,
-        octaves: i32,
-        lacunarity: f32,
-    ) -> GeneratorWrapper<DomainWarpFractalProgressive<S, G, W>>
+    pub fn domain_warp_progressive<G, W>(self, gain: G, weighted_strength: W, octaves: i32, lacunarity: f32) -> GeneratorWrapper<DomainWarpFractalProgressive<S, G, W>>
     where
         G: Hybrid,
         W: Hybrid,
@@ -95,18 +84,12 @@ where
         .into()
     }
 
-    pub fn domain_warp_independant<G, W>(
-        self,
-        gain: G,
-        weighted_strength: W,
-        octaves: i32,
-        lacunarity: f32,
-    ) -> GeneratorWrapper<DomainWarpFractalIndependant<S, G, W>>
+    pub fn domain_warp_independent<G, W>(self, gain: G, weighted_strength: W, octaves: i32, lacunarity: f32) -> GeneratorWrapper<DomainWarpFractalIndependent<S, G, W>>
     where
         G: Hybrid,
         W: Hybrid,
     {
-        DomainWarpFractalIndependant {
+        DomainWarpFractalIndependent {
             domain_warp_source: self.0,
             gain,
             weighted_strength,

--- a/fastnoise2-rs/src/generator/fractal.rs
+++ b/fastnoise2-rs/src/generator/fractal.rs
@@ -1,6 +1,5 @@
-use crate::{safe::SafeNode, Node};
-
 use super::{Generator, GeneratorWrapper, Hybrid};
+use crate::{safe::SafeNode, Node};
 
 #[derive(Clone, Debug)]
 pub struct FractalFBm<S, G, W>
@@ -30,22 +29,6 @@ where
     pub lacunarity: f32,
 }
 
-#[derive(Clone, Debug)]
-pub struct FractalPingPong<S, G, W, P>
-where
-    S: Generator,
-    G: Hybrid,
-    W: Hybrid,
-    P: Hybrid,
-{
-    pub source: S,
-    pub gain: G,
-    pub weighted_strength: W,
-    pub ping_pong_strength: P,
-    pub octaves: i32,
-    pub lacunarity: f32,
-}
-
 impl<S, G, W> Generator for FractalFBm<S, G, W>
 where
     S: Generator,
@@ -57,8 +40,7 @@ where
         let mut node = Node::from_name("FractalFBm").unwrap();
         node.set("Source", &self.source).unwrap();
         node.set("Gain", self.gain.clone()).unwrap();
-        node.set("WeightedStrength", self.weighted_strength.clone())
-            .unwrap();
+        node.set("WeightedStrength", self.weighted_strength.clone()).unwrap();
         node.set("Octaves", self.octaves).unwrap();
         node.set("Lacunarity", self.lacunarity).unwrap();
         SafeNode(node.into()).into()
@@ -76,30 +58,7 @@ where
         let mut node = Node::from_name("FractalRidged").unwrap();
         node.set("Source", &self.source).unwrap();
         node.set("Gain", self.gain.clone()).unwrap();
-        node.set("WeightedStrength", self.weighted_strength.clone())
-            .unwrap();
-        node.set("Octaves", self.octaves).unwrap();
-        node.set("Lacunarity", self.lacunarity).unwrap();
-        SafeNode(node.into()).into()
-    }
-}
-
-impl<S, G, W, P> Generator for FractalPingPong<S, G, W, P>
-where
-    S: Generator,
-    G: Hybrid,
-    W: Hybrid,
-    P: Hybrid,
-{
-    #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
-    fn build(&self) -> GeneratorWrapper<SafeNode> {
-        let mut node = Node::from_name("FractalFBm").unwrap();
-        node.set("Source", &self.source).unwrap();
-        node.set("Gain", self.gain.clone()).unwrap();
-        node.set("WeightedStrength", self.weighted_strength.clone())
-            .unwrap();
-        node.set("PingPongStrength", self.ping_pong_strength.clone())
-            .unwrap();
+        node.set("WeightedStrength", self.weighted_strength.clone()).unwrap();
         node.set("Octaves", self.octaves).unwrap();
         node.set("Lacunarity", self.lacunarity).unwrap();
         SafeNode(node.into()).into()
@@ -110,13 +69,7 @@ impl<S> GeneratorWrapper<S>
 where
     S: Generator,
 {
-    pub fn fbm<G, W>(
-        self,
-        gain: G,
-        weighted_strength: W,
-        octaves: i32,
-        lacunarity: f32,
-    ) -> GeneratorWrapper<FractalFBm<S, G, W>>
+    pub fn fbm<G, W>(self, gain: G, weighted_strength: W, octaves: i32, lacunarity: f32) -> GeneratorWrapper<FractalFBm<S, G, W>>
     where
         G: Hybrid,
         W: Hybrid,
@@ -131,13 +84,7 @@ where
         .into()
     }
 
-    pub fn ridged<G, W>(
-        self,
-        gain: G,
-        weighted_strength: W,
-        octaves: i32,
-        lacunarity: f32,
-    ) -> GeneratorWrapper<FractalRidged<S, G, W>>
+    pub fn ridged<G, W>(self, gain: G, weighted_strength: W, octaves: i32, lacunarity: f32) -> GeneratorWrapper<FractalRidged<S, G, W>>
     where
         G: Hybrid,
         W: Hybrid,
@@ -146,30 +93,6 @@ where
             source: self.0,
             gain,
             weighted_strength,
-            octaves,
-            lacunarity,
-        }
-        .into()
-    }
-
-    pub fn ping_pong<G, W, P>(
-        self,
-        gain: G,
-        weighted_strength: W,
-        ping_pong_strength: P,
-        octaves: i32,
-        lacunarity: f32,
-    ) -> GeneratorWrapper<FractalPingPong<S, G, W, P>>
-    where
-        G: Hybrid,
-        W: Hybrid,
-        P: Hybrid,
-    {
-        FractalPingPong {
-            source: self.0,
-            gain,
-            weighted_strength,
-            ping_pong_strength,
             octaves,
             lacunarity,
         }

--- a/fastnoise2-rs/src/generator/perlin.rs
+++ b/fastnoise2-rs/src/generator/perlin.rs
@@ -2,16 +2,65 @@ use crate::{safe::SafeNode, Node};
 
 use super::{Generator, GeneratorWrapper};
 
+/// Perlin gradient noise.
+/// Smooth gradient noise from N dimensional grid, developed by Ken Perlin in 1983.
 #[derive(Clone, Debug)]
-pub struct Perlin;
+pub struct Perlin {
+    /// Feature Scale (effectively 1/frequency). Default: 100.0
+    pub feature_scale: f32,
+    /// Offset applied to the seed. Default: 0
+    pub seed_offset: i32,
+    /// Minimum output value. Default: -1.0
+    pub output_min: f32,
+    /// Maximum output value. Default: 1.0
+    pub output_max: f32,
+}
+
+impl Default for Perlin {
+    fn default() -> Self {
+        Self {
+            feature_scale: 100.0,
+            seed_offset: 0,
+            output_min: -1.0,
+            output_max: 1.0,
+        }
+    }
+}
 
 impl Generator for Perlin {
     #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
     fn build(&self) -> GeneratorWrapper<SafeNode> {
-        SafeNode(Node::from_name("Perlin").unwrap().into()).into()
+        let mut node = Node::from_name("Perlin").unwrap();
+        node.set("FeatureScale", self.feature_scale).unwrap();
+        node.set("SeedOffset", self.seed_offset).unwrap();
+        node.set("OutputMin", self.output_min).unwrap();
+        node.set("OutputMax", self.output_max).unwrap();
+        SafeNode(node.into()).into()
     }
 }
 
+/// Creates a Perlin noise generator with default parameters.
 pub fn perlin() -> GeneratorWrapper<Perlin> {
-    Perlin.into()
+    Perlin::default().into()
+}
+
+impl GeneratorWrapper<Perlin> {
+    /// Sets the feature scale (effectively 1/frequency).
+    pub fn with_feature_scale(mut self, scale: f32) -> Self {
+        self.0.feature_scale = scale;
+        self
+    }
+
+    /// Sets the seed offset for variation.
+    pub fn with_seed_offset(mut self, offset: i32) -> Self {
+        self.0.seed_offset = offset;
+        self
+    }
+
+    /// Sets the output range.
+    pub fn with_output_range(mut self, min: f32, max: f32) -> Self {
+        self.0.output_min = min;
+        self.0.output_max = max;
+        self
+    }
 }

--- a/fastnoise2-rs/src/generator/simplex.rs
+++ b/fastnoise2-rs/src/generator/simplex.rs
@@ -1,27 +1,51 @@
 use super::{Generator, GeneratorWrapper};
 use crate::{safe::SafeNode, Node};
 
+/// Simplex noise generator.
 #[derive(Clone, Debug)]
 pub struct Simplex {
     /// Feature Scale (effectively 1/frequency). Default: 1.0
     pub feature_scale: f32,
+    /// Offset applied to the seed. Default: 0
+    pub seed_offset: i32,
+    /// Minimum output value. Default: -1.0
+    pub output_min: f32,
+    /// Maximum output value. Default: 1.0
+    pub output_max: f32,
 }
 
+/// SuperSimplex noise generator (K.jpg's improved simplex variant).
 #[derive(Clone, Debug)]
 pub struct SuperSimplex {
     /// Feature Scale (effectively 1/frequency). Default: 1.0
     pub feature_scale: f32,
+    /// Offset applied to the seed. Default: 0
+    pub seed_offset: i32,
+    /// Minimum output value. Default: -1.0
+    pub output_min: f32,
+    /// Maximum output value. Default: 1.0
+    pub output_max: f32,
 }
 
 impl Default for Simplex {
     fn default() -> Self {
-        Self { feature_scale: 1.0 }
+        Self {
+            feature_scale: 1.0,
+            seed_offset: 0,
+            output_min: -1.0,
+            output_max: 1.0,
+        }
     }
 }
 
 impl Default for SuperSimplex {
     fn default() -> Self {
-        Self { feature_scale: 1.0 }
+        Self {
+            feature_scale: 1.0,
+            seed_offset: 0,
+            output_min: -1.0,
+            output_max: 1.0,
+        }
     }
 }
 
@@ -29,7 +53,10 @@ impl Generator for Simplex {
     #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
     fn build(&self) -> GeneratorWrapper<SafeNode> {
         let mut node = Node::from_name("Simplex").unwrap();
-        node.set("Feature Scale", self.feature_scale).unwrap();
+        node.set("FeatureScale", self.feature_scale).unwrap();
+        node.set("SeedOffset", self.seed_offset).unwrap();
+        node.set("OutputMin", self.output_min).unwrap();
+        node.set("OutputMax", self.output_max).unwrap();
         SafeNode(node.into()).into()
     }
 }
@@ -38,7 +65,10 @@ impl Generator for SuperSimplex {
     #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
     fn build(&self) -> GeneratorWrapper<SafeNode> {
         let mut node = Node::from_name("SuperSimplex").unwrap();
-        node.set("Feature Scale", self.feature_scale).unwrap();
+        node.set("FeatureScale", self.feature_scale).unwrap();
+        node.set("SeedOffset", self.seed_offset).unwrap();
+        node.set("OutputMin", self.output_min).unwrap();
+        node.set("OutputMax", self.output_max).unwrap();
         SafeNode(node.into()).into()
     }
 }
@@ -48,6 +78,11 @@ pub fn simplex() -> GeneratorWrapper<Simplex> {
     Simplex::default().into()
 }
 
+/// Creates a Simplex noise generator with custom Feature Scale
+pub fn simplex_scaled(feature_scale: f32) -> GeneratorWrapper<Simplex> {
+    Simplex { feature_scale, ..Default::default() }.into()
+}
+
 /// Creates a SuperSimplex noise generator with default Feature Scale of 1.0
 pub fn supersimplex() -> GeneratorWrapper<SuperSimplex> {
     SuperSimplex::default().into()
@@ -55,5 +90,47 @@ pub fn supersimplex() -> GeneratorWrapper<SuperSimplex> {
 
 /// Creates a SuperSimplex noise generator with custom Feature Scale
 pub fn supersimplex_scaled(feature_scale: f32) -> GeneratorWrapper<SuperSimplex> {
-    SuperSimplex { feature_scale }.into()
+    SuperSimplex { feature_scale, ..Default::default() }.into()
+}
+
+impl GeneratorWrapper<Simplex> {
+    /// Sets the feature scale (effectively 1/frequency).
+    pub fn with_feature_scale(mut self, scale: f32) -> Self {
+        self.0.feature_scale = scale;
+        self
+    }
+
+    /// Sets the seed offset for variation.
+    pub fn with_seed_offset(mut self, offset: i32) -> Self {
+        self.0.seed_offset = offset;
+        self
+    }
+
+    /// Sets the output range.
+    pub fn with_output_range(mut self, min: f32, max: f32) -> Self {
+        self.0.output_min = min;
+        self.0.output_max = max;
+        self
+    }
+}
+
+impl GeneratorWrapper<SuperSimplex> {
+    /// Sets the feature scale (effectively 1/frequency).
+    pub fn with_feature_scale(mut self, scale: f32) -> Self {
+        self.0.feature_scale = scale;
+        self
+    }
+
+    /// Sets the seed offset for variation.
+    pub fn with_seed_offset(mut self, offset: i32) -> Self {
+        self.0.seed_offset = offset;
+        self
+    }
+
+    /// Sets the output range.
+    pub fn with_output_range(mut self, min: f32, max: f32) -> Self {
+        self.0.output_min = min;
+        self.0.output_max = max;
+        self
+    }
 }

--- a/fastnoise2-rs/src/generator/simplex.rs
+++ b/fastnoise2-rs/src/generator/simplex.rs
@@ -1,45 +1,59 @@
+use super::{Generator, GeneratorWrapper};
 use crate::{safe::SafeNode, Node};
 
-use super::{Generator, GeneratorWrapper};
+#[derive(Clone, Debug)]
+pub struct Simplex {
+    /// Feature Scale (effectively 1/frequency). Default: 1.0
+    pub feature_scale: f32,
+}
 
 #[derive(Clone, Debug)]
-pub struct Simplex;
+pub struct SuperSimplex {
+    /// Feature Scale (effectively 1/frequency). Default: 1.0
+    pub feature_scale: f32,
+}
 
-#[derive(Clone, Debug)]
-pub struct OpenSimplex2;
+impl Default for Simplex {
+    fn default() -> Self {
+        Self { feature_scale: 1.0 }
+    }
+}
 
-#[derive(Clone, Debug)]
-pub struct OpenSimplex2S;
+impl Default for SuperSimplex {
+    fn default() -> Self {
+        Self { feature_scale: 1.0 }
+    }
+}
 
 impl Generator for Simplex {
     #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
     fn build(&self) -> GeneratorWrapper<SafeNode> {
-        SafeNode(Node::from_name("Simplex").unwrap().into()).into()
+        let mut node = Node::from_name("Simplex").unwrap();
+        node.set("Feature Scale", self.feature_scale).unwrap();
+        SafeNode(node.into()).into()
     }
 }
 
-impl Generator for OpenSimplex2 {
+impl Generator for SuperSimplex {
     #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
     fn build(&self) -> GeneratorWrapper<SafeNode> {
-        SafeNode(Node::from_name("OpenSimplex2").unwrap().into()).into()
+        let mut node = Node::from_name("SuperSimplex").unwrap();
+        node.set("Feature Scale", self.feature_scale).unwrap();
+        SafeNode(node.into()).into()
     }
 }
 
-impl Generator for OpenSimplex2S {
-    #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
-    fn build(&self) -> GeneratorWrapper<SafeNode> {
-        SafeNode(Node::from_name("OpenSimplex2S").unwrap().into()).into()
-    }
-}
-
+/// Creates a Simplex noise generator with default Feature Scale of 1.0
 pub fn simplex() -> GeneratorWrapper<Simplex> {
-    Simplex.into()
+    Simplex::default().into()
 }
 
-pub fn opensimplex2() -> GeneratorWrapper<OpenSimplex2> {
-    OpenSimplex2.into()
+/// Creates a SuperSimplex noise generator with default Feature Scale of 1.0
+pub fn supersimplex() -> GeneratorWrapper<SuperSimplex> {
+    SuperSimplex::default().into()
 }
 
-pub fn opensimplex2s() -> GeneratorWrapper<OpenSimplex2S> {
-    OpenSimplex2S.into()
+/// Creates a SuperSimplex noise generator with custom Feature Scale
+pub fn supersimplex_scaled(feature_scale: f32) -> GeneratorWrapper<SuperSimplex> {
+    SuperSimplex { feature_scale }.into()
 }

--- a/fastnoise2-rs/src/generator/value.rs
+++ b/fastnoise2-rs/src/generator/value.rs
@@ -2,16 +2,65 @@ use crate::{safe::SafeNode, Node};
 
 use super::{Generator, GeneratorWrapper};
 
+/// Value noise generator.
+/// Smooth gradient noise from N dimensional grid.
 #[derive(Clone, Debug)]
-pub struct Value;
+pub struct Value {
+    /// Feature Scale (effectively 1/frequency). Default: 100.0
+    pub feature_scale: f32,
+    /// Offset applied to the seed. Default: 0
+    pub seed_offset: i32,
+    /// Minimum output value. Default: -1.0
+    pub output_min: f32,
+    /// Maximum output value. Default: 1.0
+    pub output_max: f32,
+}
+
+impl Default for Value {
+    fn default() -> Self {
+        Self {
+            feature_scale: 100.0,
+            seed_offset: 0,
+            output_min: -1.0,
+            output_max: 1.0,
+        }
+    }
+}
 
 impl Generator for Value {
     #[cfg_attr(feature = "trace", tracing::instrument(level = "trace"))]
     fn build(&self) -> GeneratorWrapper<SafeNode> {
-        SafeNode(Node::from_name("Value").unwrap().into()).into()
+        let mut node = Node::from_name("Value").unwrap();
+        node.set("FeatureScale", self.feature_scale).unwrap();
+        node.set("SeedOffset", self.seed_offset).unwrap();
+        node.set("OutputMin", self.output_min).unwrap();
+        node.set("OutputMax", self.output_max).unwrap();
+        SafeNode(node.into()).into()
     }
 }
 
+/// Creates a Value noise generator with default parameters.
 pub fn value() -> GeneratorWrapper<Value> {
-    Value.into()
+    Value::default().into()
+}
+
+impl GeneratorWrapper<Value> {
+    /// Sets the feature scale (effectively 1/frequency).
+    pub fn with_feature_scale(mut self, scale: f32) -> Self {
+        self.0.feature_scale = scale;
+        self
+    }
+
+    /// Sets the seed offset for variation.
+    pub fn with_seed_offset(mut self, offset: i32) -> Self {
+        self.0.seed_offset = offset;
+        self
+    }
+
+    /// Sets the output range.
+    pub fn with_output_range(mut self, min: f32, max: f32) -> Self {
+        self.0.output_min = min;
+        self.0.output_max = max;
+        self
+    }
 }

--- a/fastnoise2-rs/src/lib_test.rs
+++ b/fastnoise2-rs/src/lib_test.rs
@@ -1,0 +1,757 @@
+use super::*;
+use generator::prelude::*;
+use generator::{
+    cellular::{cellular_distance_full, cellular_lookup_full, cellular_value_full, CellularDistanceReturnType},
+    domain_warp::VectorizationScheme,
+    modifier::PlaneRotationType,
+    simplex::supersimplex_scaled,
+    Dimension, DistanceFunction, FadeInterpolation,
+};
+
+/// Helper to test a generator produces valid noise output
+fn test_generator_produces_output(node: SafeNode) {
+    let mut output = [0.0f32; 16];
+    let min_max = node.gen_uniform_grid_2d(&mut output, 0.0, 0.0, 4, 4, 0.1, 0.1, 1337);
+    // Check that we got valid output
+    assert!(min_max.min.is_finite());
+    assert!(min_max.max.is_finite());
+    // Check that not all values are the same (noise should vary)
+    let all_same = output.iter().all(|&v| v == output[0]);
+    // Some generators (like Constant) will have all same values, which is fine
+    assert!(all_same || output.iter().any(|&v| v != output[0]));
+}
+
+// ==================== Basic Generators ====================
+
+#[test]
+fn test_constant() {
+    let node = constant(0.5).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_white_noise() {
+    let node = white().build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_checkerboard() {
+    let node = checkerboard(10.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_sinewave() {
+    let node = sinewave(10.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_gradient() {
+    let node = gradient([0.01, 0.01, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_distance_to_point() {
+    let node = distance_to_point(DistanceFunction::Euclidean, [0.0, 0.0, 0.0, 0.0]).build();
+    test_generator_produces_output(node.0);
+}
+
+// ==================== Coherent Noise ====================
+
+#[test]
+fn test_perlin() {
+    let node = perlin().build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_simplex() {
+    let node = simplex().build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_supersimplex() {
+    let node = supersimplex().build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_value() {
+    let node = generator::value::value().build();
+    test_generator_produces_output(node.0);
+}
+
+// ==================== Cellular ====================
+
+#[test]
+fn test_cellular_value() {
+    let node = cellular_value(1.0, DistanceFunction::EuclideanSquared, 0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_cellular_value_with_minkowski() {
+    let node = cellular_value_full(1.0, DistanceFunction::Minkowski, 0, 1.5, 0.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_cellular_distance() {
+    let node = cellular_distance(1.0, DistanceFunction::EuclideanSquared, 0, 1, CellularDistanceReturnType::Index0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_cellular_distance_full() {
+    let node = cellular_distance_full(
+        1.0,
+        DistanceFunction::Minkowski,
+        0,
+        1,
+        CellularDistanceReturnType::Index0Sub1,
+        2.0, // minkowski_p
+        0.1, // size_jitter
+    )
+    .build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_cellular_lookup() {
+    let node = cellular_lookup(perlin(), 1.0, DistanceFunction::Euclidean).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_cellular_lookup_full() {
+    let node = cellular_lookup_full(
+        simplex(),
+        1.0,
+        DistanceFunction::Minkowski,
+        1.5, // minkowski_p
+        0.0, // size_jitter
+    )
+    .build();
+    test_generator_produces_output(node.0);
+}
+
+// ==================== Fractals ====================
+
+#[test]
+fn test_fractal_fbm() {
+    let node = perlin().fbm(0.5, 0.0, 4, 2.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_fractal_ridged() {
+    let node = perlin().ridged(0.5, 0.0, 4, 2.0).build();
+    test_generator_produces_output(node.0);
+}
+
+// ==================== Domain Warp ====================
+
+#[test]
+fn test_domain_warp_gradient() {
+    let node = simplex().domain_warp_gradient(50.0, 100.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_domain_warp_simplex() {
+    let node = perlin().domain_warp_simplex(50.0, 100.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_domain_warp_simplex_with_scheme() {
+    let node = perlin().domain_warp_simplex_with_scheme(50.0, 100.0, VectorizationScheme::GradientOuterProduct).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_domain_warp_super_simplex() {
+    let node = perlin().domain_warp_super_simplex(50.0, 100.0).build();
+    test_generator_produces_output(node.0);
+}
+
+// ==================== Domain Warp Fractal ====================
+
+#[test]
+fn test_domain_warp_fractal_progressive() {
+    // Domain warp fractal methods work on DomainWarpNode types
+    let node = perlin().domain_warp_gradient(50.0, 100.0).domain_warp_progressive(0.5, 0.0, 4, 2.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_domain_warp_fractal_independent() {
+    let node = perlin().domain_warp_gradient(50.0, 100.0).domain_warp_independent(0.5, 0.0, 4, 2.0).build();
+    test_generator_produces_output(node.0);
+}
+
+// ==================== Operators ====================
+
+#[test]
+fn test_add() {
+    let node = (perlin() + 0.5).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_subtract() {
+    let node = (perlin() - simplex()).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_multiply() {
+    let node = (perlin() * 2.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_divide() {
+    let node = (perlin() / 2.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_modulus() {
+    let node = (perlin() % 0.5).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_min() {
+    let node = perlin().min(0.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_max() {
+    let node = perlin().max(0.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_negate() {
+    let node = (-perlin()).build();
+    test_generator_produces_output(node.0);
+}
+
+// ==================== Blends ====================
+
+#[test]
+fn test_min_smooth() {
+    let node = perlin().min_smooth(simplex(), 0.1).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_max_smooth() {
+    let node = perlin().max_smooth(simplex(), 0.1).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_fade() {
+    let node = perlin().fade(simplex(), 0.5).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_fade_with_range() {
+    let node = perlin().fade_with_range(simplex(), 0.5, -1.0, 1.0, FadeInterpolation::Hermite).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_powf() {
+    let node = perlin().abs().powf(2.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_powi() {
+    let node = perlin().powi(2).build();
+    test_generator_produces_output(node.0);
+}
+
+// ==================== Modifiers ====================
+
+#[test]
+fn test_domain_scale() {
+    let node = perlin().domain_scale(0.5).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_domain_offset() {
+    let node = perlin().domain_offset(1.0, 2.0, 0.0, 0.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_domain_rotate() {
+    let node = perlin().domain_rotate(0.5, 0.0, 0.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_seed_offset() {
+    let node = perlin().seed_offset(42).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_remap() {
+    let node = perlin().remap(-1.0, 1.0, 0.0, 1.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_terrace() {
+    let node = perlin().terrace(4.0, 0.5).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_domain_axis_scale() {
+    let node = perlin().domain_axis_scale([1.0, 2.0, 1.0, 1.0]).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_add_dimension() {
+    let node = perlin().add_dimension(0.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_remove_dimension() {
+    let node = perlin().remove_dimension(Dimension::Z).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_cache() {
+    let node = perlin().cache().build();
+    test_generator_produces_output(node.0);
+}
+
+// ==================== New Modifiers ====================
+
+#[test]
+fn test_ping_pong() {
+    let node = perlin().ping_pong(2.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_abs() {
+    let node = perlin().abs().build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_signed_sqrt() {
+    let node = perlin().signed_sqrt().build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_domain_rotate_plane() {
+    let node = perlin().domain_rotate_plane().build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_domain_rotate_plane_xz() {
+    let node = perlin().domain_rotate_plane_with_type(PlaneRotationType::ImproveXZPlanes).build();
+    test_generator_produces_output(node.0);
+}
+
+// ==================== Complex Combinations ====================
+
+#[test]
+fn test_complex_terrain() {
+    // A complex terrain generator combining multiple features
+    let base = perlin().fbm(0.5, 0.0, 6, 2.0);
+    let detail = simplex().fbm(0.6, 0.0, 4, 2.5);
+    let warped = base.domain_warp_gradient(20.0, 100.0);
+    let combined = warped.min_smooth(detail, 0.2);
+    let node = combined.remap(-1.0, 1.0, 0.0, 1.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_ridged_mountains() {
+    let node = perlin().ridged(0.5, 0.5, 5, 2.0).abs().terrace(8.0, 0.3).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_cellular_with_domain_warp() {
+    let node = cellular_value(1.0, DistanceFunction::Euclidean, 0).domain_warp_simplex(30.0, 100.0).build();
+    test_generator_produces_output(node.0);
+}
+
+// ==================== Single Point Generation ====================
+
+#[test]
+fn test_gen_single_2d() {
+    let node = perlin().build();
+    let value = node.0.gen_single_2d(0.5, 0.5, 1337);
+    assert!(value.is_finite());
+    assert!(value >= -1.5 && value <= 1.5); // Perlin should be roughly -1 to 1
+}
+
+#[test]
+fn test_gen_single_3d() {
+    let node = perlin().build();
+    let value = node.0.gen_single_3d(0.5, 0.5, 0.5, 1337);
+    assert!(value.is_finite());
+}
+
+// ==================== Distance Functions ====================
+
+#[test]
+fn test_all_distance_functions() {
+    let functions = [
+        DistanceFunction::Euclidean,
+        DistanceFunction::EuclideanSquared,
+        DistanceFunction::Manhattan,
+        DistanceFunction::Hybrid,
+        DistanceFunction::MaxAxis,
+        DistanceFunction::Minkowski,
+    ];
+
+    for func in functions {
+        let node = cellular_value(1.0, func, 0).build();
+        test_generator_produces_output(node.0);
+    }
+}
+
+// ==================== Encoded Node Tree ====================
+
+#[test]
+fn test_encoded_node_tree() {
+    let encoded = "DQAFAAAAAAAAQAgAAAAAAD8="; // Simple Perlin
+    let node = SafeNode::from_encoded_node_tree(encoded);
+    // This might fail if the encoded string is invalid
+    if let Ok(node) = node {
+        test_generator_produces_output(node);
+    }
+}
+
+// ==================== Generation Output Methods ====================
+
+#[test]
+fn test_gen_uniform_grid_3d() {
+    let node = perlin().build();
+    let mut output = [0.0f32; 64]; // 4x4x4
+    let min_max = node.0.gen_uniform_grid_3d(&mut output, 0.0, 0.0, 0.0, 4, 4, 4, 0.1, 0.1, 0.1, 1337);
+    assert!(min_max.min.is_finite());
+    assert!(min_max.max.is_finite());
+    assert!(output.iter().any(|&v| v != output[0]));
+}
+
+#[test]
+fn test_gen_uniform_grid_4d() {
+    let node = perlin().build();
+    let mut output = [0.0f32; 16]; // 2x2x2x2
+    let min_max = node.0.gen_uniform_grid_4d(&mut output, 0.0, 0.0, 0.0, 0.0, 2, 2, 2, 2, 0.1, 0.1, 0.1, 0.1, 1337);
+    assert!(min_max.min.is_finite());
+    assert!(min_max.max.is_finite());
+    assert!(output.iter().any(|&v| v != output[0]));
+}
+
+#[test]
+fn test_gen_position_array_2d() {
+    let node = perlin().build();
+    let x_pos = [0.0, 0.1, 0.2, 0.3];
+    let y_pos = [0.0, 0.1, 0.2, 0.3];
+    let mut output = [0.0f32; 4];
+    let min_max = node.0.gen_position_array_2d(&mut output, &x_pos, &y_pos, 0.0, 0.0, 1337);
+    assert!(min_max.min.is_finite());
+    assert!(min_max.max.is_finite());
+    assert!(output.iter().all(|&v| v.is_finite()));
+}
+
+#[test]
+fn test_gen_position_array_3d() {
+    let node = perlin().build();
+    let x_pos = [0.0, 0.1, 0.2, 0.3];
+    let y_pos = [0.0, 0.1, 0.2, 0.3];
+    let z_pos = [0.0, 0.1, 0.2, 0.3];
+    let mut output = [0.0f32; 4];
+    let min_max = node.0.gen_position_array_3d(&mut output, &x_pos, &y_pos, &z_pos, 0.0, 0.0, 0.0, 1337);
+    assert!(min_max.min.is_finite());
+    assert!(min_max.max.is_finite());
+    assert!(output.iter().all(|&v| v.is_finite()));
+}
+
+#[test]
+fn test_gen_position_array_4d() {
+    let node = perlin().build();
+    let x_pos = [0.0, 0.1, 0.2, 0.3];
+    let y_pos = [0.0, 0.1, 0.2, 0.3];
+    let z_pos = [0.0, 0.1, 0.2, 0.3];
+    let w_pos = [0.0, 0.1, 0.2, 0.3];
+    let mut output = [0.0f32; 4];
+    let min_max = node.0.gen_position_array_4d(&mut output, &x_pos, &y_pos, &z_pos, &w_pos, 0.0, 0.0, 0.0, 0.0, 1337);
+    assert!(min_max.min.is_finite());
+    assert!(min_max.max.is_finite());
+    assert!(output.iter().all(|&v| v.is_finite()));
+}
+
+#[test]
+fn test_gen_tileable_2d() {
+    let node = perlin().build();
+    let mut output = [0.0f32; 16]; // 4x4
+    let min_max = node.0.gen_tileable_2d(&mut output, 4, 4, 0.1, 0.1, 1337);
+    assert!(min_max.min.is_finite());
+    assert!(min_max.max.is_finite());
+    assert!(output.iter().any(|&v| v != output[0]));
+}
+
+#[test]
+fn test_gen_single_4d() {
+    let node = perlin().build();
+    let value = node.0.gen_single_4d(0.5, 0.5, 0.5, 0.5, 1337);
+    assert!(value.is_finite());
+}
+
+// ==================== Additional Node Types ====================
+
+#[test]
+fn test_supersimplex_scaled() {
+    let node = supersimplex_scaled(0.5).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_convert_rgba8() {
+    // ConvertRgba8 outputs packed RGBA8 data as floats, so we just verify
+    // it can be constructed and called without crashing
+    let node = perlin().convert_rgba8(-1.0, 1.0).build();
+    let mut output = [0.0f32; 16];
+    // This won't produce standard noise values - it packs RGBA8 into floats
+    let _min_max = node.0.gen_uniform_grid_2d(&mut output, 0.0, 0.0, 4, 4, 0.1, 0.1, 1337);
+    // Just verify the node runs without crashing
+}
+
+#[test]
+fn test_recip() {
+    // recip() creates 1.0 / value
+    let node = (constant(2.0) + constant(0.0)).recip().build();
+    let mut output = [0.0f32; 4];
+    let min_max = node.0.gen_uniform_grid_2d(&mut output, 0.0, 0.0, 2, 2, 0.1, 0.1, 1337);
+    assert!(min_max.min.is_finite());
+    assert!(min_max.max.is_finite());
+    // 1/2 = 0.5
+    assert!(output.iter().all(|&v| (v - 0.5).abs() < 0.001));
+}
+
+#[test]
+fn test_domain_warp_super_simplex_with_scheme() {
+    let node = perlin()
+        .domain_warp_super_simplex_with_scheme(50.0, 100.0, VectorizationScheme::GradientOuterProduct)
+        .build();
+    test_generator_produces_output(node.0);
+}
+
+// ==================== CellularDistanceReturnType Variants ====================
+
+#[test]
+fn test_cellular_distance_return_types() {
+    let return_types = [
+        CellularDistanceReturnType::Index0,
+        CellularDistanceReturnType::Index0Add1,
+        CellularDistanceReturnType::Index0Sub1,
+        CellularDistanceReturnType::Index0Mul1,
+        CellularDistanceReturnType::Index0Div1,
+    ];
+
+    for return_type in return_types {
+        let node = cellular_distance(1.0, DistanceFunction::EuclideanSquared, 0, 1, return_type).build();
+        test_generator_produces_output(node.0);
+    }
+}
+
+// ==================== FadeInterpolation Variants ====================
+
+#[test]
+fn test_fade_interpolation_linear() {
+    let node = perlin()
+        .fade_with_range(simplex(), 0.5, -1.0, 1.0, FadeInterpolation::Linear)
+        .build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_fade_interpolation_quintic() {
+    let node = perlin()
+        .fade_with_range(simplex(), 0.5, -1.0, 1.0, FadeInterpolation::Quintic)
+        .build();
+    test_generator_produces_output(node.0);
+}
+
+// ==================== Dimension Variants ====================
+
+#[test]
+fn test_remove_dimension_all() {
+    let dimensions = [Dimension::X, Dimension::Y, Dimension::Z, Dimension::W];
+    for dim in dimensions {
+        let node = perlin().remove_dimension(dim).build();
+        test_generator_produces_output(node.0);
+    }
+}
+
+// ==================== PlaneRotationType Variants ====================
+
+#[test]
+fn test_plane_rotation_types() {
+    let rotation_types = [PlaneRotationType::ImproveXYPlanes, PlaneRotationType::ImproveXZPlanes];
+    for rotation_type in rotation_types {
+        let node = perlin().domain_rotate_plane_with_type(rotation_type).build();
+        test_generator_produces_output(node.0);
+    }
+}
+
+// ==================== VectorizationScheme Variants ====================
+
+#[test]
+fn test_vectorization_schemes() {
+    let schemes = [VectorizationScheme::OrthogonalGradientMatrix, VectorizationScheme::GradientOuterProduct];
+    for scheme in schemes {
+        let node = perlin().domain_warp_simplex_with_scheme(50.0, 100.0, scheme).build();
+        test_generator_produces_output(node.0);
+    }
+}
+
+// ==================== SIMD Level ====================
+
+#[test]
+fn test_get_simd_level() {
+    let node = perlin().build();
+    let simd_level = node.0.get_simd_level();
+    // Just verify we can get a SIMD level - the actual value depends on the system
+    // SIMD levels: 0=Scalar, 1=SSE, 2=SSE2, 3=SSE3, 4=SSSE3, 5=SSE41, 6=SSE42,
+    //              7=AVX, 8=AVX2, 9=AVX512
+    // On systems with AVX-512 this will be higher
+    assert!(simd_level < u32::MAX); // Just verify it's a valid number
+}
+
+// ==================== Hybrid Parameters with Generators ====================
+
+#[test]
+fn test_hybrid_gain_fbm() {
+    // Using a generator as the gain parameter (hybrid)
+    let gain_node = simplex().domain_scale(0.1);
+    let node = perlin().fbm(gain_node, 0.0, 4, 2.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_hybrid_weighted_strength_ridged() {
+    // Using a generator as weighted_strength parameter
+    let strength_node = simplex().domain_scale(0.1);
+    let node = perlin().ridged(0.5, strength_node, 4, 2.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_hybrid_warp_amplitude() {
+    // Using a generator as warp amplitude (hybrid)
+    let amplitude_node = simplex().remap(-1.0, 1.0, 10.0, 50.0);
+    let node = perlin().domain_warp_gradient(amplitude_node, 100.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_hybrid_cellular_jitter() {
+    // Using a generator for grid jitter
+    let jitter_node = simplex().remap(-1.0, 1.0, 0.5, 1.5);
+    let node = cellular_value(jitter_node, DistanceFunction::Euclidean, 0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_hybrid_domain_offset() {
+    // Using generators for offset parameters
+    let offset_gen = simplex().domain_scale(0.1);
+    let node = perlin().domain_offset(offset_gen.clone(), offset_gen, 0.0, 0.0).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_hybrid_add_dimension() {
+    // Using a generator for new dimension position
+    let pos_gen = simplex();
+    let node = perlin().add_dimension(pos_gen).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_hybrid_ping_pong() {
+    // Using a generator for ping pong strength
+    let strength_gen = simplex().remap(-1.0, 1.0, 1.0, 3.0);
+    let node = perlin().ping_pong(strength_gen).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_hybrid_fade() {
+    // Using a generator for fade value
+    let fade_gen = simplex();
+    let node = perlin().fade(value(), fade_gen).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_hybrid_min_smooth() {
+    // Using a generator for smoothness
+    let smooth_gen = simplex().remap(-1.0, 1.0, 0.05, 0.2);
+    let node = perlin().min_smooth(value(), smooth_gen).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_hybrid_powf() {
+    // Using a generator for power
+    let pow_gen = simplex().remap(-1.0, 1.0, 1.5, 2.5);
+    let node = perlin().abs().powf(pow_gen).build();
+    test_generator_produces_output(node.0);
+}
+
+// ==================== Generator as Operand ====================
+
+#[test]
+fn test_generator_add_generator() {
+    let node = (perlin() + simplex()).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_generator_multiply_generator() {
+    let node = (perlin() * simplex()).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_generator_min_generator() {
+    let node = perlin().min(simplex()).build();
+    test_generator_produces_output(node.0);
+}
+
+#[test]
+fn test_generator_max_generator() {
+    let node = perlin().max(simplex()).build();
+    test_generator_produces_output(node.0);
+}

--- a/fastnoise2-rs/src/metadata.rs
+++ b/fastnoise2-rs/src/metadata.rs
@@ -249,12 +249,15 @@ impl MemberValue for &Node {
     fn apply(&self, node: &mut Node, member: &Member) -> Result<(), FastNoiseError> {
         match member.member_type {
             MemberType::NodeLookup => {
-                if !unsafe { fnSetNodeLookup(node.handle, member.index, self.handle) } {
+                // C API expects pointer to SmartNode-like structure (pointer at offset 0)
+                // Pass address of handle so C can dereference to get the Generator*
+                if !unsafe { fnSetNodeLookup(node.handle, member.index, &self.handle as *const _ as *const _) } {
                     return Err(FastNoiseError::SetNodeLookupFailed);
                 }
             }
             MemberType::Hybrid => {
-                if !unsafe { fnSetHybridNodeLookup(node.handle, member.index, self.handle) } {
+                // Same fix for hybrid node lookups
+                if !unsafe { fnSetHybridNodeLookup(node.handle, member.index, &self.handle as *const _ as *const _) } {
                     return Err(FastNoiseError::SetHybridNodeLookupFailed);
                 }
             }

--- a/fastnoise2-rs/src/safe.rs
+++ b/fastnoise2-rs/src/safe.rs
@@ -28,98 +28,116 @@ impl SafeNode {
     }
 
     /// # Panics
-    /// Panics if `noise_out.len() < x_size * y_size`.
+    /// Panics if `noise_out.len() < x_count * y_count`.
     pub fn gen_uniform_grid_2d(
         &self,
         noise_out: &mut [f32],
-        x_start: i32,
-        y_start: i32,
-        x_size: i32,
-        y_size: i32,
-        frequency: f32,
+        x_offset: f32,
+        y_offset: f32,
+        x_count: i32,
+        y_count: i32,
+        x_step_size: f32,
+        y_step_size: f32,
         seed: i32,
     ) -> OutputMinMax {
-        assert!(noise_out.len() >= (x_size * y_size) as usize);
+        assert!(noise_out.len() >= (x_count * y_count) as usize);
 
         unsafe {
             self.0.gen_uniform_grid_2d_unchecked(
-                noise_out, x_start, y_start, x_size, y_size, frequency, seed,
+                noise_out,
+                x_offset,
+                y_offset,
+                x_count,
+                y_count,
+                x_step_size,
+                y_step_size,
+                seed,
             )
         }
     }
 
     /// # Panics
-    /// Panics if `noise_out.len() < x_size * y_size * z_size`.
+    /// Panics if `noise_out.len() < x_count * y_count * z_count`.
     pub fn gen_uniform_grid_3d(
         &self,
         noise_out: &mut [f32],
-        x_start: i32,
-        y_start: i32,
-        z_start: i32,
-        x_size: i32,
-        y_size: i32,
-        z_size: i32,
-        frequency: f32,
+        x_offset: f32,
+        y_offset: f32,
+        z_offset: f32,
+        x_count: i32,
+        y_count: i32,
+        z_count: i32,
+        x_step_size: f32,
+        y_step_size: f32,
+        z_step_size: f32,
         seed: i32,
     ) -> OutputMinMax {
-        assert!(noise_out.len() >= (x_size * y_size * z_size) as usize);
+        assert!(noise_out.len() >= (x_count * y_count * z_count) as usize);
 
         unsafe {
             self.0.gen_uniform_grid_3d_unchecked(
-                noise_out, x_start, y_start, z_start, x_size, y_size, z_size, frequency, seed,
+                noise_out,
+                x_offset,
+                y_offset,
+                z_offset,
+                x_count,
+                y_count,
+                z_count,
+                x_step_size,
+                y_step_size,
+                z_step_size,
+                seed,
             )
         }
     }
 
     /// # Panics
-    /// Panics if `noise_out.len() < x_size * y_size * z_size * w_size`.
+    /// Panics if `noise_out.len() < x_count * y_count * z_count * w_count`.
     pub fn gen_uniform_grid_4d(
         &self,
         noise_out: &mut [f32],
-        x_start: i32,
-        y_start: i32,
-        z_start: i32,
-        w_start: i32,
-        x_size: i32,
-        y_size: i32,
-        z_size: i32,
-        w_size: i32,
-        frequency: f32,
+        x_offset: f32,
+        y_offset: f32,
+        z_offset: f32,
+        w_offset: f32,
+        x_count: i32,
+        y_count: i32,
+        z_count: i32,
+        w_count: i32,
+        x_step_size: f32,
+        y_step_size: f32,
+        z_step_size: f32,
+        w_step_size: f32,
         seed: i32,
     ) -> OutputMinMax {
-        assert!(noise_out.len() >= (x_size * y_size * z_size * w_size) as usize);
+        assert!(noise_out.len() >= (x_count * y_count * z_count * w_count) as usize);
 
         unsafe {
             self.0.gen_uniform_grid_4d_unchecked(
-                noise_out, x_start, y_start, z_start, w_start, x_size, y_size, z_size, w_size,
-                frequency, seed,
+                noise_out,
+                x_offset,
+                y_offset,
+                z_offset,
+                w_offset,
+                x_count,
+                y_count,
+                z_count,
+                w_count,
+                x_step_size,
+                y_step_size,
+                z_step_size,
+                w_step_size,
+                seed,
             )
         }
     }
 
     /// # Panics
     /// Panics if `noise_out`, `x_pos_array`, and `y_pos_array` do not have the same length.
-    pub fn gen_position_array_2d(
-        &self,
-        noise_out: &mut [f32],
-        x_pos_array: &[f32],
-        y_pos_array: &[f32],
-        x_offset: f32,
-        y_offset: f32,
-        seed: i32,
-    ) -> OutputMinMax {
+    pub fn gen_position_array_2d(&self, noise_out: &mut [f32], x_pos_array: &[f32], y_pos_array: &[f32], x_offset: f32, y_offset: f32, seed: i32) -> OutputMinMax {
         assert!(noise_out.len() == x_pos_array.len() && x_pos_array.len() == y_pos_array.len());
 
-        unsafe {
-            self.0.gen_position_array_2d_unchecked(
-                noise_out,
-                x_pos_array,
-                y_pos_array,
-                x_offset,
-                y_offset,
-                seed,
-            )
-        }
+        unsafe { self.0.gen_position_array_2d_unchecked(noise_out, x_pos_array, y_pos_array, x_offset, y_offset, seed) }
     }
 
     /// # Panics
@@ -199,14 +217,21 @@ impl SafeNode {
         noise_out: &mut [f32],
         x_size: i32,
         y_size: i32,
-        frequency: f32,
+        x_step_size: f32,
+        y_step_size: f32,
         seed: i32,
     ) -> OutputMinMax {
         assert!(noise_out.len() >= (x_size * y_size) as usize);
 
         unsafe {
-            self.0
-                .gen_tileable_2d_unchecked(noise_out, x_size, y_size, frequency, seed)
+            self.0.gen_tileable_2d_unchecked(
+                noise_out,
+                x_size,
+                y_size,
+                x_step_size,
+                y_step_size,
+                seed,
+            )
         }
     }
 

--- a/fastnoise2-sys/README.md
+++ b/fastnoise2-sys/README.md
@@ -6,7 +6,7 @@ Low-level Rust FFI bindings for [FastNoise2](https://github.com/Auburn/FastNoise
 
 ### Native Platforms (Linux, Windows, macOS)
 
-Native builds use cmake and work out of the box:
+Native builds use [CMake](https://cmake.org/) and require a C++17 compiler:
 
 ```bash
 cargo build

--- a/fastnoise2-sys/README.md
+++ b/fastnoise2-sys/README.md
@@ -1,0 +1,84 @@
+# fastnoise2-sys
+
+Low-level Rust FFI bindings for [FastNoise2](https://github.com/Auburn/FastNoise2), a high-performance noise generation library with SIMD support.
+
+## Building
+
+### Native Platforms (Linux, Windows, macOS)
+
+Native builds use cmake and work out of the box:
+
+```bash
+cargo build
+```
+
+### WebAssembly (WASM)
+
+WASM builds require the [Emscripten SDK](https://emscripten.org/):
+
+#### 1. Install Emscripten
+
+```bash
+# Clone the emsdk repository
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+
+# Install and activate Emscripten 3.1.68 or later
+./emsdk install 3.1.68
+./emsdk activate 3.1.68
+
+# Add Emscripten to your environment
+source ./emsdk_env.sh
+```
+
+**Note**: You need to run `source ./emsdk_env.sh` in each new terminal session before building for WASM.
+
+#### 2. Build for WASM
+
+```bash
+cargo build --target wasm32-unknown-emscripten
+```
+
+The build script will automatically detect the Emscripten target and use Emscripten to compile FastNoise2.
+
+#### Custom Emscripten Flags
+
+You can pass custom flags to emcc via the `EMCC_CFLAGS` environment variable:
+
+```bash
+export EMCC_CFLAGS="-s ERROR_ON_UNDEFINED_SYMBOLS=0"
+cargo build --target wasm32-unknown-emscripten
+```
+
+## Environment Variables
+
+| Variable | Purpose | Required |
+|----------|---------|----------|
+| `EMSDK` | Path to Emscripten SDK | Yes (WASM only) |
+| `EMCC_CFLAGS` | Custom flags for emcc | No |
+| `FASTNOISE2_SOURCE_DIR` | Override FastNoise2 source path | No |
+| `FASTNOISE2_LIB_DIR` | Use precompiled library | No |
+| `FASTNOISE2_BINDINGS_DIR` | Cache directory for bindings | No |
+
+## Troubleshooting
+
+### Error: "EMSDK environment variable required for WASM builds"
+
+You need to install and activate the Emscripten SDK (see instructions above), then source the environment:
+
+```bash
+source /path/to/emsdk/emsdk_env.sh
+```
+
+### Slow bindgen compilation
+
+Set `FASTNOISE2_BINDINGS_DIR` to cache generated bindings:
+
+```bash
+export FASTNOISE2_BINDINGS_DIR=~/.cache/fastnoise2-bindings
+cargo build --target wasm32-unknown-emscripten
+```
+
+## License
+
+This crate provides bindings to FastNoise2, which is licensed under the MIT License.

--- a/fastnoise2-sys/build/main.rs
+++ b/fastnoise2-sys/build/main.rs
@@ -2,6 +2,7 @@ use std::{env, path::PathBuf};
 
 const SOURCE_DIR_KEY: &str = "FASTNOISE2_SOURCE_DIR";
 const LIB_DIR_KEY: &str = "FASTNOISE2_LIB_DIR";
+const BINDINGS_CACHE_KEY: &str = "FASTNOISE2_BINDINGS_DIR";
 const LIB_NAME: &str = "FastNoise";
 const HEADER_NAME: &str = "FastNoise_C.h";
 
@@ -14,13 +15,22 @@ fn main() {
 
     println!("cargo:rerun-if-env-changed={SOURCE_DIR_KEY}");
     println!("cargo:rerun-if-env-changed={LIB_DIR_KEY}");
+    println!("cargo:rerun-if-env-changed={BINDINGS_CACHE_KEY}");
+    println!("cargo:rerun-if-env-changed=EMSDK");
 
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+
+    // WASM builds use pure WASM with SIMD128
+    if target_arch == "wasm32" {
+        build_wasm();
+        return; // WASM doesn't need C++ stdlib linking
+    }
+
+    // Native builds follow existing logic
     let feature_build_from_source = env::var("CARGO_FEATURE_BUILD_FROM_SOURCE").is_ok();
 
     if feature_build_from_source {
-        println!(
-            "cargo:warning=feature 'build-from-source' is enabled; building FastNoise2 from source"
-        );
+        println!("cargo:warning=feature 'build-from-source' is enabled; building FastNoise2 from source");
         build_from_source();
     } else if let Ok(lib_dir) = env::var(LIB_DIR_KEY) {
         println!("cargo:warning=using precompiled library located in '{lib_dir}'");
@@ -36,32 +46,84 @@ fn main() {
     emit_std_cpp_link();
 }
 
-fn build_from_source() {
-    let source_path = env::var(SOURCE_DIR_KEY)
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| default_source_path());
+fn build_wasm() {
+    let source_path = env::var(SOURCE_DIR_KEY).map(PathBuf::from).unwrap_or_else(|_| default_source_path());
 
-    println!(
-        "cargo:warning=building from source files located in '{}'",
-        source_path.display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        source_path.join("include").join("FastNoise").display()
-    );
+    println!("cargo:warning=Building FastNoise2 for WASM with SIMD128 support");
+
+    // Log the EMSDK path if set (for debugging)
+    if let Ok(emsdk) = env::var("EMSDK") {
+        println!("cargo:warning=EMSDK path: {}", emsdk);
+    }
+    println!("cargo:rerun-if-changed={}", source_path.join("include").join("FastNoise").display());
+
+    // Get Emscripten SDK path from environment
+    let emsdk_path = env::var("EMSDK").expect("EMSDK environment variable required for WASM builds. Install from https://emscripten.org");
+
+    // Use Emscripten's CMake toolchain file - this properly configures compilers and sysroot
+    let toolchain_file = format!("{}/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake", emsdk_path);
+
+    // Build FastNoise2 for WASM as a pure static library using Emscripten toolchain
+    // FastSIMD has native WASM SIMD128 support - we just need to enable it
+    let mut config = cmake::Config::new(&source_path);
+    config
+        .profile("Release")
+        .define("CMAKE_TOOLCHAIN_FILE", &toolchain_file)
+        .define("FASTNOISE2_TOOLS", "OFF")
+        .define("FASTNOISE2_TESTS", "OFF")
+        .define("FASTNOISE2_UTILITY", "OFF") // Disable utility to avoid Corrade dependency
+        .define("BUILD_SHARED_LIBS", "OFF");
+
+    // Enable WASM SIMD128 only (no threading/atomics for compatibility with simple WASM demos)
+    // NOTE: If Rust is built with --shared-memory, FastNoise2 also needs atomics (-pthread)
+    // For now, keep it simple and let individual projects add atomics if needed
+    let wasm_flags = "-msimd128";
+    config.define("CMAKE_C_FLAGS", wasm_flags);
+    config.define("CMAKE_CXX_FLAGS", wasm_flags);
+
+    let out_path = config.build();
+    let lib_path = out_path.join("lib");
+    let lib64_path = out_path.join("lib64");
+
+    println!("cargo:rustc-link-search=native={}", lib_path.display());
+    println!("cargo:rustc-link-search=native={}", lib64_path.display());
+    println!("cargo:rustc-link-lib=static={LIB_NAME}");
+
+    // Copy Utility headers that cmake doesn't install
+    let src_utility = source_path.join("include").join("FastNoise").join("Utility");
+    let dst_utility = out_path.join("include").join("FastNoise").join("Utility");
+    if src_utility.exists() && !dst_utility.exists() {
+        std::fs::create_dir_all(&dst_utility).expect("Failed to create Utility dir");
+        for entry in std::fs::read_dir(&src_utility).expect("Failed to read Utility dir") {
+            let entry = entry.expect("Failed to read entry");
+            let dst = dst_utility.join(entry.file_name());
+            std::fs::copy(entry.path(), &dst).expect("Failed to copy header");
+        }
+    }
+
+    generate_bindings(out_path);
+}
+
+fn build_from_source() {
+    let source_path = env::var(SOURCE_DIR_KEY).map(PathBuf::from).unwrap_or_else(|_| default_source_path());
+
+    println!("cargo:warning=building from source files located in '{}'", source_path.display());
+    println!("cargo:rerun-if-changed={}", source_path.join("include").join("FastNoise").display());
 
     let mut config = cmake::Config::new(&source_path);
     config
         .profile("Release")
-        .define("FASTNOISE2_NOISETOOL", "OFF")
+        .define("FASTNOISE2_TOOLS", "OFF")
         .define("FASTNOISE2_TESTS", "OFF")
+        .define("FASTNOISE2_UTILITY", "OFF")
         .define("BUILD_SHARED_LIBS", "OFF");
 
     // https://github.com/rust-lang/cmake-rs/issues/198:
-    // cmake-rs add default arguments such as CMAKE_CXX_FLAGS_RELEASE to the build command.
-    // Removing these would automatically add Release profile args to allow for better execution performance.
-    // FastNoise2 wiki steps for compiling the library (https://github.com/Auburn/FastNoise2/wiki/Compiling-FastNoise2):
-    // 1. cmake -S . -B build -D FASTNOISE2_NOISETOOL=OFF -D FASTNOISE2_TESTS=OFF -D BUILD_SHARED_LIBS=OFF
+    // cmake-rs add default arguments such as CMAKE_CXX_FLAGS_RELEASE to the build
+    // command. Removing these would automatically add Release profile args to
+    // allow for better execution performance. FastNoise2 wiki steps for compiling the library (https://github.com/Auburn/FastNoise2/wiki/Compiling-FastNoise2):
+    // 1. cmake -S . -B build -D FASTNOISE2_NOISETOOL=OFF -D FASTNOISE2_TESTS=OFF -D
+    //    BUILD_SHARED_LIBS=OFF
     // 2. cmake --build build --config Release
     // This give us optimized build (with MSVC):
     // -> build/CMakeCache.txt: CMAKE_CXX_FLAGS_RELEASE:STRING=/MD /O2 /Ob2 /DNDEBUG
@@ -73,13 +135,16 @@ fn build_from_source() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
 
-    let cmake_cxx_flags_release =  match (target_os.as_str(), target_env.as_str()) {
+    let cmake_cxx_flags_release = match (target_os.as_str(), target_env.as_str()) {
         ("windows", "msvc") => "/MD /O2 /Ob2 /DNDEBUG",
         // For GCC/Clang (Linux, macOS, MinGW)
         _ => "-O3 -DNDEBUG",
     };
 
-    println!("cargo:warning=CARGO_CFG_TARGET_OS='{target_os}' and CARGO_CFG_TARGET_ENV='{target_env}' => CMAKE_CXX_FLAGS_RELEASE='{cmake_cxx_flags_release}'");
+    println!(
+        "cargo:warning=CARGO_CFG_TARGET_OS='{target_os}' and CARGO_CFG_TARGET_ENV='{target_env}' => \
+     CMAKE_CXX_FLAGS_RELEASE='{cmake_cxx_flags_release}'"
+    );
     config.define("CMAKE_CXX_FLAGS_RELEASE", cmake_cxx_flags_release);
 
     let out_path = config.build();
@@ -90,33 +155,79 @@ fn build_from_source() {
     println!("cargo:rustc-link-search=native={}", lib64_path.display());
     println!("cargo:rustc-link-lib=static={LIB_NAME}");
 
+    // Copy Utility headers that cmake doesn't install
+    let src_utility = source_path.join("include").join("FastNoise").join("Utility");
+    let dst_utility = out_path.join("include").join("FastNoise").join("Utility");
+    if src_utility.exists() && !dst_utility.exists() {
+        std::fs::create_dir_all(&dst_utility).expect("Failed to create Utility dir");
+        for entry in std::fs::read_dir(&src_utility).expect("Failed to read Utility dir") {
+            let entry = entry.expect("Failed to read entry");
+            let dst = dst_utility.join(entry.file_name());
+            std::fs::copy(entry.path(), &dst).expect("Failed to copy header");
+        }
+    }
+
     generate_bindings(out_path);
 }
 
 fn generate_bindings(source_path: PathBuf) {
-    println!("cargo:warning=generating Rust bindings for FastNoise2");
-
-    let header_path = source_path
-        .join("include")
-        .join("FastNoise")
-        .join(HEADER_NAME);
-    let bindings = bindgen::Builder::default()
-        .header(header_path.to_str().unwrap())
-        // 'bool' exists in C++ but not directly in C, it is named _Bool or you can use 'bool' by including 'stdbool.h'
-        .clang_arg("-xc++")
-        .generate()
-        .expect("Unable to generate bindings");
-
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     let bindings_path = out_path.join("bindings.rs");
-    bindings
-        .write_to_file(&bindings_path)
-        .expect("Couldn't write bindings!");
+
+    // Check for cached bindings first
+    if let Ok(cache_dir) = env::var(BINDINGS_CACHE_KEY) {
+        let cached_bindings = PathBuf::from(&cache_dir).join("bindings.rs");
+        if cached_bindings.exists() {
+            println!("cargo:warning=using cached bindings from '{}'", cached_bindings.display());
+            std::fs::copy(&cached_bindings, &bindings_path).expect("Failed to copy cached bindings");
+            return;
+        }
+    }
 
     println!(
-        "cargo:warning=bindings generated successfully and written to '{}'",
-        bindings_path.display()
+        "cargo:warning=generating Rust bindings for FastNoise2 (this is slow, set \
+     FASTNOISE2_BINDINGS_DIR to cache)"
     );
+
+    let include_path = source_path.join("include").join("FastNoise");
+    let header_path = include_path.join(HEADER_NAME);
+
+    // FastNoise C API bindings are target-agnostic (pure extern "C" declarations
+    // with only primitive types like c_int, c_void, f32, bool).
+    // We explicitly generate for the HOST system, not the cross-compile target,
+    // because bindgen/libclang fails when targeting WASM (produces empty output).
+    // This is safe because the C ABI for these declarations is identical across platforms.
+    let mut builder = bindgen::Builder::default()
+        .header(header_path.to_str().unwrap())
+        .clang_arg(format!("-I{}", include_path.to_str().unwrap()))
+        .clang_arg("-xc++")
+        .clang_arg("-fno-exceptions");
+
+    // When cross-compiling (e.g., to WASM), force bindgen to use host target
+    // instead of the cross-compile target. This works because the FastNoise C API
+    // only uses portable types (c_int, c_uint, c_void*, f32, bool).
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    if target_arch == "wasm32" {
+        // Use host triple for parsing - the bindings are ABI-compatible
+        let host = env::var("HOST").unwrap_or_else(|_| "x86_64-unknown-linux-gnu".to_string());
+        println!("cargo:warning=cross-compiling to WASM, using host target '{}' for bindgen", host);
+        builder = builder.clang_arg(format!("--target={}", host));
+    }
+
+    let bindings = builder.generate().expect("Unable to generate bindings");
+
+    bindings.write_to_file(&bindings_path).expect("Couldn't write bindings!");
+
+    println!("cargo:warning=bindings generated successfully and written to '{}'", bindings_path.display());
+
+    // Save to cache if dir is set
+    if let Ok(cache_dir) = env::var(BINDINGS_CACHE_KEY) {
+        let cache_path = PathBuf::from(&cache_dir);
+        std::fs::create_dir_all(&cache_path).ok();
+        let cached_bindings = cache_path.join("bindings.rs");
+        std::fs::copy(&bindings_path, &cached_bindings).ok();
+        println!("cargo:warning=bindings cached to '{}'", cached_bindings.display());
+    }
 }
 
 fn default_source_path() -> PathBuf {

--- a/fastnoise2-sys/build/main.rs
+++ b/fastnoise2-sys/build/main.rs
@@ -110,6 +110,12 @@ fn build_from_source() {
     println!("cargo:warning=building from source files located in '{}'", source_path.display());
     println!("cargo:rerun-if-changed={}", source_path.join("include").join("FastNoise").display());
 
+    // Pre-create pdb-files directory structure to prevent CMake install failure on Windows
+    // FastNoise2's CMakeLists.txt tries to install PDB files that may not exist in Release builds
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let pdb_dir = out_dir.join("build").join("pdb-files").join("Release");
+    std::fs::create_dir_all(&pdb_dir).ok();
+
     let mut config = cmake::Config::new(&source_path);
     config
         .profile("Release")

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+edition = "2024"
+tab_spaces = 4
+max_width = 100


### PR DESCRIPTION
## Summary

Update to FastNoise2 v0.4.0 with native WASM SIMD128 support and expanded API.

**New generators:** `PingPong`, `Abs`, `SignedSquareRoot`, `DomainRotatePlane`, `DomainWarpSimplex`, `DomainWarpSuperSimplex`, `Modulus`

**New features:**
- Native WASM SIMD128 via NewFastSIMD integration
- Minkowski distance function for Cellular types
- Builder methods for all generator parameters (`feature_scale`, `seed_offset`, `output_range`)
- Hybrid parameters that accept constants or generators

**Breaking changes:**
- Renamed: `OpenSimplex2` → `SuperSimplex`, `PositionOutput` → `Gradient`, `SquareRoot` → `SignedSquareRoot`
- Field renames: `scale` → `scaling`, `multiplier` → `step_count`, `jitter_modifier` → `grid_jitter`
- `Simplex` changed from unit struct to struct with fields
- Removed `FractalPingPong` (use `PingPong` modifier instead)

See [CHANGELOG.md](https://github.com/api-haus/fastnoise2-rs/blob/main/CHANGELOG.md) for full migration guide.
